### PR TITLE
Checkmate

### DIFF
--- a/Chess.iml
+++ b/Chess.iml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="Infinitest" name="Infinitest">
+      <configuration />
+    </facet>
+  </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
@@ -21,4 +26,3 @@
     <orderEntry type="library" scope="TEST" name="Maven: com.fluxchess:jcpi:test-jar:tests:1.4.0" level="project" />
   </component>
 </module>
-

--- a/src/main/java/com/leokom/chess/PlayerFactory.java
+++ b/src/main/java/com/leokom/chess/PlayerFactory.java
@@ -59,7 +59,7 @@ final class PlayerFactory {
 
 		switch ( engineName ) {
 			case "Legal":
-				return new LegalPlayer( side );
+				return new LegalPlayer();
 			case "SimpleEngine":
 				return new SimpleEnginePlayer( side );
 			case "Winboard":

--- a/src/main/java/com/leokom/chess/engine/InitialPosition.java
+++ b/src/main/java/com/leokom/chess/engine/InitialPosition.java
@@ -68,6 +68,8 @@ final class InitialPosition {
 			result.add( side, initialKingFile + rank, PieceType.KING );
 		}
 
+		result.setSideToMove( Side.WHITE );
+
 		return result;
 	}
 }

--- a/src/main/java/com/leokom/chess/engine/InitialPosition.java
+++ b/src/main/java/com/leokom/chess/engine/InitialPosition.java
@@ -37,7 +37,7 @@ final class InitialPosition {
 	}
 
 	static Position generate() {
-		final Position result = new Position();
+		final Position result = new Position( Side.WHITE );
 
 		final Set< String > initialRookFiles = new HashSet<>( Arrays.asList( "a", "h" ) );
 		final Set< String > initialKnightFiles = new HashSet<>( Arrays.asList( "b", "g" ) );
@@ -67,8 +67,6 @@ final class InitialPosition {
 			result.add( side, initialQueenFile + rank, PieceType.QUEEN );
 			result.add( side, initialKingFile + rank, PieceType.KING );
 		}
-
-		result.setSideToMove( Side.WHITE );
 
 		return result;
 	}

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -58,6 +58,8 @@ public class Position {
 
 	private Set< Side > hasHRookMoved = new HashSet<>();
 
+	private Side sideToMove = Side.WHITE;
+
 	void setHasKingMoved( Side side ) {
 		this.hasKingMoved.add( side );
 	}
@@ -792,5 +794,9 @@ public class Position {
 
 	public Stream< Piece > getPieces( Side side ) {
 		return pieces.values().stream().filter( piece -> piece.getSide() == side );
+	}
+
+	public Side getSideToMove() {
+		return sideToMove;
 	}
 }

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -669,6 +669,11 @@ public class Position {
 	 * @return new position, which is received from current by making 1 move
 	 */
 	public Position move( Move move ) {
+		//TODO: think about better place for validation
+		if ( pieces.get( move.getFrom() ).getSide() != sideToMove ) {
+			throw new IllegalArgumentException( "Wrong move : " + move );
+		}
+
 		return new PositionGenerator( this ).generate( move );
 	}
 

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -848,4 +848,32 @@ public class Position {
 	void setSideToMove( Side sideToMove ) {
 		this.sideToMove = sideToMove;
 	}
+
+	/**
+	 * Check if position is terminal
+	 * (final, meaning end of game).
+	 * No more moves are legal from a terminal position
+	 *
+	 * @return true if position is terminal
+	 */
+	public boolean isTerminal() {
+		return getMoves().isEmpty();
+	}
+
+	/**
+	 * Get side that has won the game
+	 *
+	 * @return side that has won the game
+	 *
+	 * @throws java.lang.IllegalStateException when game is not finished yet
+	 */
+	public Side getWinningSide() {
+		if ( !isTerminal() ) {
+			throw new IllegalStateException( "Game has not yet finished" );
+		}
+
+		//funny easy implementation that takes into account
+		//just Checkmate possibility
+		return sideToMove.opposite();
+	}
 }

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -780,8 +780,13 @@ public class Position {
 		add( piece.getSide(), to, piece.getPieceType() );
 	}
 
-	//TODO: probably moving side must be a part of the position itself
-	//to be decided what's better representation for moves.
+	/**
+	 *
+	 * @param side
+	 * @deprecated use #getMoves() instead
+	 * @return
+	 */
+	@Deprecated
 	public Set< Move > getMoves( Side side ) {
 		final Set< Move > result = new HashSet<>();
 
@@ -791,6 +796,10 @@ public class Position {
 		}
 
 		return result;
+	}
+
+	public Set< Move > getMoves() {
+		return getMoves( sideToMove );
 	}
 
 	public Stream< Piece > getPieces( Side side ) {

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -107,6 +107,7 @@ public class Position {
 	/**
 	 * Get moves that are available from the square provided
 	 * @param square square currently in format like 'e2' (this we'll call further as 'canonical representation')
+	 *               PRE-CONDITION: there is some piece on the square.
 	 * @return not-null set of available moves from square (could be empty for sure)
 	 *
 	 * Move is now interpreted as following:
@@ -116,10 +117,8 @@ public class Position {
 	 * 2) square's canonical representation + upper-case of promoted piece from pawn (e.g. a8N -
 	 * if we promoted to Knight)
 	 *
-	 * TODO: what if square doesn't contain any pieces?
-	 * Should we return empty set, null or throw an exception?
 	 */
-	public Set<String> getMovesFrom( String square ) {
+	Set<String> getMovesFrom( String square ) {
 		final Set<String> potentialMoves = getPotentialMoves( square );
 
 		//3.1 It is not permitted to move a piece to a square occupied by a piece of the same colour.

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -682,7 +682,7 @@ public class Position {
 	 * Copy state (like info if the king has moved)
 	 * @param position destination position
 	 */
-	void copyPiecesInto( Position position ) {
+	void copyStateTo( Position position ) {
 		//cloning position
 		for ( String square : pieces.keySet() ) {
 			//looks safe as both keys and pieces are IMMUTABLE
@@ -694,6 +694,21 @@ public class Position {
 		position.hasKingMoved = new HashSet<>( this.hasKingMoved );
 		position.hasARookMoved = new HashSet<>( this.hasARookMoved );
 		position.hasHRookMoved = new HashSet<>( this.hasHRookMoved );
+	}
+
+	/**
+	 * Create 'mirror' position.
+	 * Since Position now encapsulates full game state
+	 * (including side to move)
+	 * this is the way to create the same position with a single difference
+	 * side to move is opposite
+	 *
+	 * @return mirror position
+	 */
+	public Position toMirror() {
+		Position position = new Position( this.sideToMove.opposite() );
+		copyStateTo( position );
+		return position;
 	}
 
 	/**
@@ -788,25 +803,20 @@ public class Position {
 	}
 
 	/**
-	 *
-	 * @param side
-	 * @deprecated use #getMoves() instead
-	 * @return
+	 * Get set of moves possible from the position.
+	 * Since it encapsulates side - the moves are collected
+	 * for #getSideToMove()
+	 * @return set of possible legal moves
 	 */
-	@Deprecated
-	public Set< Move > getMoves( Side side ) {
+	public Set< Move > getMoves() {
 		final Set< Move > result = new HashSet<>();
 
-		final Set<String> squares = getSquaresOccupiedBySide( side );
+		final Set<String> squares = getSquaresOccupiedBySide( sideToMove );
 		for ( String square : squares ) {
 			result.addAll( getMovesFrom( square ).stream().map( move -> new Move( square, move ) ).collect( toSet() ) );
 		}
 
 		return result;
-	}
-
-	public Set< Move > getMoves() {
-		return getMoves( sideToMove );
 	}
 
 	public Stream< Piece > getPieces( Side side ) {

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -346,9 +346,7 @@ public class Position {
 		return result;
 	}
 
-	//TODO: side must be part of Position, isn't it?
 	private boolean isKingInCheck( Side side ) {
-
 		final String kingSquare = findKing( side );
 		//TODO: null is impossible in real chess, possible in our tests...
 		return kingSquare != null && isSquareAttacked( side, kingSquare );

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -12,10 +12,21 @@ import static com.leokom.chess.utils.CollectionUtils.addIfNotNull;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * Current position on-board (probably with some historical data...)
+ * Current position on-board
+ * It contains all game state that's important
+ * to take decisions about possible moves.
  *
- * I consider the position as immutable (however this vision may change
- * by taking into account historical data)
+ * Thus it contains historical data like
+ * <ul>
+ *     <li>Side that can execute a move right now</li>
+ *     <li>Has king moved?</li>
+ *     <li>Has rook moved?</li>
+ * </ul>
+ *
+ * The position SHOULD be immutable. This is a strict desired state
+ * of th class.
+ * Mutators that exist here MUST be moved to some 'position builder'
+ *
  *
  * Author: Leonid
  * Date-time: 21.08.12 15:55

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -100,11 +100,8 @@ public class Position {
 	 *
 	 * By default en passant file is absent
 	 *
-	 * @deprecated Use Position( Side sideToMove ) instead
+	 * @param sideToMove side which turn will be now
 	 */
-	public Position() {
-	}
-
 	public Position( Side sideToMove ) {
 		this.sideToMove = sideToMove;
 	}

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -69,8 +69,7 @@ public class Position {
 
 	private Set< Side > hasHRookMoved = new HashSet<>();
 
-	//TODO: this initialization to avoid NPE in OLD tests.
-	private Side sideToMove = Side.WHITE;
+	private Side sideToMove;
 
 
 	void setHasKingMoved( Side side ) {

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -670,8 +670,12 @@ public class Position {
 	 */
 	public Position move( Move move ) {
 		//TODO: think about better place for validation
+		if ( pieces.get( move.getFrom() ) == null ) {
+			throw new IllegalArgumentException( "Source square is empty : " + move.getFrom() );
+		}
+
 		if ( pieces.get( move.getFrom() ).getSide() != sideToMove ) {
-			throw new IllegalArgumentException( "Wrong move : " + move );
+			throw new IllegalArgumentException( "Wrong side to move : " + move + ". Currently it's turn of " + sideToMove );
 		}
 
 		return new PositionGenerator( this ).generate( move );

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -61,6 +61,7 @@ public class Position {
 	//TODO: this initialization to avoid NPE in OLD tests.
 	private Side sideToMove = Side.WHITE;
 
+
 	void setHasKingMoved( Side side ) {
 		this.hasKingMoved.add( side );
 	}
@@ -88,8 +89,14 @@ public class Position {
 	 * are considered to be not have moved before) which might be inconsistent with actual position
 	 *
 	 * By default en passant file is absent
+	 *
+	 * @deprecated Use Position( Side sideToMove ) instead
 	 */
 	public Position() {
+	}
+
+	public Position( Side sideToMove ) {
+		this.sideToMove = sideToMove;
 	}
 
 	private static final int VALID_SQUARE_LENGTH = 2;

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -125,6 +125,8 @@ public class Position {
 		//3.1 It is not permitted to move a piece to a square occupied by a piece of the same colour.
 		potentialMoves.removeAll( getSquaresOccupiedBySide( getSide( square ) ) );
 
+		// 3.9 'No piece can be moved that will ... expose the king of the same colour to check
+		//... or leave that king in check' is also covered here.
 		potentialMoves.removeAll( getSquaresThatExposeOurKingToCheck( square, potentialMoves ) );
 
 		//1.2 ’capturing’ the opponent’s king ... not allowed

--- a/src/main/java/com/leokom/chess/engine/Position.java
+++ b/src/main/java/com/leokom/chess/engine/Position.java
@@ -58,6 +58,7 @@ public class Position {
 
 	private Set< Side > hasHRookMoved = new HashSet<>();
 
+	//TODO: this initialization to avoid NPE in OLD tests.
 	private Side sideToMove = Side.WHITE;
 
 	void setHasKingMoved( Side side ) {
@@ -798,5 +799,9 @@ public class Position {
 
 	public Side getSideToMove() {
 		return sideToMove;
+	}
+
+	void setSideToMove( Side sideToMove ) {
+		this.sideToMove = sideToMove;
 	}
 }

--- a/src/main/java/com/leokom/chess/engine/PositionBuilder.java
+++ b/src/main/java/com/leokom/chess/engine/PositionBuilder.java
@@ -1,0 +1,31 @@
+package com.leokom.chess.engine;
+
+
+/**
+ * Create position in fluent-interface style
+ *
+ *
+ * Author: Leonid
+ * Date-time: 28.02.15 22:05
+ */
+public class PositionBuilder {
+	final Position position;
+
+	public PositionBuilder() {
+		position = new Position();
+	}
+
+	public PositionBuilder add( Side side, String square, PieceType pieceType ) {
+		position.add( side, square, pieceType );
+		return this;
+	}
+
+	public PositionBuilder setSideOf( String square ) {
+		position.setSideToMove( position.getSide( square ) );
+		return this;
+	}
+
+	public Position build() {
+		return position;
+	}
+}

--- a/src/main/java/com/leokom/chess/engine/PositionBuilder.java
+++ b/src/main/java/com/leokom/chess/engine/PositionBuilder.java
@@ -12,7 +12,9 @@ public class PositionBuilder {
 	final Position position;
 
 	public PositionBuilder() {
-		position = new Position();
+		//TODO: not the best decision to hard-code side here
+		//better delay position construction till build() method call
+		position = new Position( Side.WHITE );
 	}
 
 	public PositionBuilder add( Side side, String square, PieceType pieceType ) {

--- a/src/main/java/com/leokom/chess/engine/PositionBuilder.java
+++ b/src/main/java/com/leokom/chess/engine/PositionBuilder.java
@@ -28,4 +28,9 @@ public class PositionBuilder {
 	public Position build() {
 		return position;
 	}
+
+	public PositionBuilder addPawn( Side side, String square ) {
+		position.addPawn( side, square );
+		return this;
+	}
 }

--- a/src/main/java/com/leokom/chess/engine/PositionBuilder.java
+++ b/src/main/java/com/leokom/chess/engine/PositionBuilder.java
@@ -33,4 +33,19 @@ public class PositionBuilder {
 		position.addPawn( side, square );
 		return this;
 	}
+
+	public PositionBuilder addQueen( Side side, String square ) {
+		position.addQueen( side, square );
+		return this;
+	}
+
+	public Position move( String from, String to ) {
+		setSideOf( from );
+		return position.move( from, to );
+	}
+
+	public PositionBuilder setEnPassantFile( String enPassantFile ) {
+		position.setEnPassantFile( enPassantFile );
+		return this;
+	}
 }

--- a/src/main/java/com/leokom/chess/engine/PositionBuilder.java
+++ b/src/main/java/com/leokom/chess/engine/PositionBuilder.java
@@ -9,7 +9,7 @@ package com.leokom.chess.engine;
  * Date-time: 28.02.15 22:05
  */
 public class PositionBuilder {
-	final Position position;
+	private final Position position;
 
 	public PositionBuilder() {
 		//TODO: not the best decision to hard-code side here

--- a/src/main/java/com/leokom/chess/engine/PositionGenerator.java
+++ b/src/main/java/com/leokom/chess/engine/PositionGenerator.java
@@ -26,12 +26,6 @@ final class PositionGenerator {
 	 * @return new position, after move from squareFrom
 	 */
 	Position generate( Move move ) {
-		final Position newPosition = getNewPosition( move );
-		newPosition.setSideToMove( source.getSideToMove().opposite() );
-		return newPosition;
-	}
-
-	private Position getNewPosition( Move move ) {
 		String squareFrom = move.getFrom();
 		String moveTo = move.getTo();
 		final PieceType pieceType = source.getPieceType( squareFrom );
@@ -103,7 +97,10 @@ final class PositionGenerator {
 
 		final String newEnPassantFile = getNewEnPassantFile( squareFrom, squareTo );
 
-		final Position result = new Position();
+
+		final Side movingSide = source.getSideToMove();
+
+		final Position result = new Position( movingSide.opposite() );
 		result.setEnPassantFile( newEnPassantFile );
 		cloneAndRemove( result, squareFrom );
 
@@ -113,8 +110,6 @@ final class PositionGenerator {
 		if ( enPassantCapturedPawnSquare != null ) {
 			result.removePiece( enPassantCapturedPawnSquare );
 		}
-
-		final Side movingSide = source.getSide( squareFrom );
 
 		if ( Move.isPromotion( move ) ) {
 			//depends on 3-char format
@@ -141,8 +136,8 @@ final class PositionGenerator {
 	 */
 	private Position processMoveWithoutSideEffects( String squareFrom, String move ) {
 		//after moving everything except a pawn
-		//we clear the flag about en passant possibility
-		final Position position = new Position();
+		//we don't set (thus clearing) the flag about en passant possibility
+		final Position position = new Position( source.getSideToMove().opposite() );
 		cloneAndRemove( position, squareFrom );
 
 		position.add( source.getSide( squareFrom ), move, source.getPieceType( squareFrom ) );

--- a/src/main/java/com/leokom/chess/engine/PositionGenerator.java
+++ b/src/main/java/com/leokom/chess/engine/PositionGenerator.java
@@ -157,7 +157,7 @@ final class PositionGenerator {
 	 * @param squareFrom will be empty in the newPosition
 	 */
 	private void cloneAndRemove( Position newPosition, String squareFrom ) {
-		source.copyPiecesInto( newPosition );
+		source.copyStateTo( newPosition );
 
 		newPosition.removePiece( squareFrom );
 	}

--- a/src/main/java/com/leokom/chess/engine/PositionGenerator.java
+++ b/src/main/java/com/leokom/chess/engine/PositionGenerator.java
@@ -26,6 +26,12 @@ final class PositionGenerator {
 	 * @return new position, after move from squareFrom
 	 */
 	Position generate( Move move ) {
+		final Position newPosition = getNewPosition( move );
+		newPosition.setSideToMove( source.getSideToMove().opposite() );
+		return newPosition;
+	}
+
+	private Position getNewPosition( Move move ) {
 		String squareFrom = move.getFrom();
 		String moveTo = move.getTo();
 		final PieceType pieceType = source.getPieceType( squareFrom );

--- a/src/main/java/com/leokom/chess/player/legalMover/CastlingSafetyEvaluator.java
+++ b/src/main/java/com/leokom/chess/player/legalMover/CastlingSafetyEvaluator.java
@@ -32,7 +32,7 @@ class CastlingSafetyEvaluator implements Evaluator {
 	public double evaluateMove( Position position, Move move ) {
 		//if king has moved already - all other moves are fine
 		//they don't bring anything for castling safety
-		final Side side = position.getSide( move.getFrom() );
+		final Side side = position.getSideToMove();
 
 		if ( position.hasKingMoved( side ) ) {
 			return ACCEPTABLE_MOVE;

--- a/src/main/java/com/leokom/chess/player/legalMover/CenterControlEvaluator.java
+++ b/src/main/java/com/leokom/chess/player/legalMover/CenterControlEvaluator.java
@@ -30,8 +30,7 @@ class CenterControlEvaluator implements Evaluator {
 		//e.g. Knight on e5 cannot attack e4, d4, d5
 		//but blocks the center
 
-
-		final Side ourSide = position.getSide( move.getFrom() );
+		final Side ourSide = position.getSideToMove();
 
 		final Position targetPosition = position.move( move );
 		//technically it's naive check - since the situation

--- a/src/main/java/com/leokom/chess/player/legalMover/LegalPlayer.java
+++ b/src/main/java/com/leokom/chess/player/legalMover/LegalPlayer.java
@@ -2,7 +2,6 @@ package com.leokom.chess.player.legalMover;
 
 import com.leokom.chess.engine.Move;
 import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
 import com.leokom.chess.player.Player;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,16 +16,13 @@ import java.util.Set;
  * Date-time: 09.12.13 22:02
  */
 public class LegalPlayer implements Player {
-	private Side side;
 	private Player opponent;
 	private Position position = Position.getInitialPosition();
 
 	/**
-	 * Create player that will play for the side
-	 * @param side who we play for?
+	 * Create player
 	 */
-	public LegalPlayer( Side side ) {
-		this.side = side;
+	public LegalPlayer() {
 	}
 
 	@Override
@@ -42,7 +38,6 @@ public class LegalPlayer implements Player {
 	@Override
 	public void opponentSuggestsMeStartNewGameWhite() {
 		getLogger().info( "Opponent suggested me started a new game whites. Starting it" );
-		side = Side.WHITE;
 		position = Position.getInitialPosition();
 		executeMove();
 	}
@@ -66,7 +61,7 @@ public class LegalPlayer implements Player {
 
 	//exposing package-private for tests
 	void executeMove() {
-		Set< Move > legalMoves = position.getMoves( side );
+		Set< Move > legalMoves = position.getMoves();
 
 		if ( !legalMoves.isEmpty() ) {
 			Move move = findBestMove( legalMoves );
@@ -88,8 +83,9 @@ public class LegalPlayer implements Player {
 
 	//updating internal representation of current position according to our move
 	private void updateInternalPositionPresentation( Move move ) {
+		getLogger().info( this.position.getSideToMove() + " : Moved " + move );
 		position = position.move( move );
-		getLogger().info( this.side + " : Moved " + move + "\nNew position : " + position );
+		getLogger().info( "\nNew position : " + position );
 	}
 
 	/**

--- a/src/main/java/com/leokom/chess/player/legalMover/LegalPlayer.java
+++ b/src/main/java/com/leokom/chess/player/legalMover/LegalPlayer.java
@@ -76,8 +76,9 @@ public class LegalPlayer implements Player {
 			informOpponentAboutTheMove( move );
 		}
 		else {
-			getLogger().info( "Final state detected" );
-			//TODO: if empty set it means the game has been finished (what's the result?)
+			getLogger().info( "We cannot execute any moves." +
+					" Final state has been detected." +
+					" Result will be based on Position information " );
 		}
 	}
 

--- a/src/main/java/com/leokom/chess/player/legalMover/MaterialEvaluator.java
+++ b/src/main/java/com/leokom/chess/player/legalMover/MaterialEvaluator.java
@@ -19,7 +19,7 @@ public class MaterialEvaluator implements Evaluator {
 	public double evaluateMove( Position position, Move move ) {
 		final Position target = position.move( move );
 
-		Side ourSide = position.getSide( move.getFrom() );
+		Side ourSide = position.getSideToMove();
 
 		Stream< Piece > ourPieces = target.getPieces( ourSide );
 		Stream< Piece > opponentPieces = target.getPieces( ourSide.opposite() );

--- a/src/main/java/com/leokom/chess/player/legalMover/MobilityEvaluator.java
+++ b/src/main/java/com/leokom/chess/player/legalMover/MobilityEvaluator.java
@@ -2,7 +2,6 @@ package com.leokom.chess.player.legalMover;
 
 import com.leokom.chess.engine.Move;
 import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
 
 /**
  * If inside a position there is a bigger variety of moves
@@ -29,9 +28,7 @@ public class MobilityEvaluator implements Evaluator {
 	public double evaluateMove( Position position, Move move ) {
 		final Position target = position.move( move );
 
-		final Side ourSide = position.getSideToMove();
-
-		final int legalMoves = target.getMoves( ourSide ).size();
+		final int legalMoves = target.toMirror().getMoves().size();
 		return (double) legalMoves / MAXIMAL_POSSIBLE_MOVES;
 	}
 }

--- a/src/main/java/com/leokom/chess/player/legalMover/MobilityEvaluator.java
+++ b/src/main/java/com/leokom/chess/player/legalMover/MobilityEvaluator.java
@@ -29,7 +29,7 @@ public class MobilityEvaluator implements Evaluator {
 	public double evaluateMove( Position position, Move move ) {
 		final Position target = position.move( move );
 
-		final Side ourSide = position.getSide( move.getFrom() );
+		final Side ourSide = position.getSideToMove();
 
 		final int legalMoves = target.getMoves( ourSide ).size();
 		return (double) legalMoves / MAXIMAL_POSSIBLE_MOVES;

--- a/src/main/java/com/leokom/chess/player/uci/UciPlayer.java
+++ b/src/main/java/com/leokom/chess/player/uci/UciPlayer.java
@@ -13,8 +13,6 @@ import java.util.Set;
 public final class UciPlayer extends AbstractEngine {
 
   private Position position = Position.getInitialPosition();
-  private Side sideToMove = Side.WHITE;
-
   public static void main(String[] args) {
     new UciPlayer().run();
   }
@@ -61,7 +59,7 @@ public final class UciPlayer extends AbstractEngine {
   public void receive(EngineAnalyzeCommand command) {
     new EngineStopCalculatingCommand().accept(this);
 
-	  position = new Position();
+	  position = new Position( command.board.getActiveColor() == GenericColor.WHITE ? Side.WHITE : Side.BLACK );
 
     for (GenericPosition genericPosition : GenericPosition.values()) {
       GenericPiece genericPiece = command.board.getPiece(genericPosition);
@@ -95,13 +93,11 @@ public final class UciPlayer extends AbstractEngine {
       }
     }
 
-    sideToMove = command.board.getActiveColor() == GenericColor.WHITE ? Side.WHITE : Side.BLACK;
 
     for (GenericMove genericMove : command.moves) {
       position = position.move(
           genericMove.from.toString(),
           genericMove.to.toString() + (genericMove.promotion == null ? "" : genericMove.promotion.toCharAlgebraic()));
-      sideToMove = sideToMove == Side.WHITE ? Side.BLACK : Side.WHITE;
     }
   }
 
@@ -109,7 +105,7 @@ public final class UciPlayer extends AbstractEngine {
   public void receive(EngineStartCalculatingCommand command) {
     new EngineStopCalculatingCommand().accept(this);
 
-    Set<Move> moves = position.getMoves(sideToMove);
+    Set<Move> moves = position.getMoves();
     if (!moves.isEmpty()) {
       Move possibleMove = moves.iterator().next();
 

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardCommander.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardCommander.java
@@ -1,5 +1,7 @@
 package com.leokom.chess.player.winboard;
 
+import com.leokom.chess.engine.Side;
+
 /**
  * Low-level Winboard-commands for some abstraction and easier testing.
  * The 'on' methods set up listeners to some events received from Winboard server
@@ -46,7 +48,8 @@ interface WinboardCommander {
 	void onResign( ResignListener listener );
 
 	/**
-	 * Inform Winboard that opponent has won
+	 * Inform Winboard that the side has won by checkmate
+	 * @param side winning by checkmate side
 	 */
-	void opponentWon();
+	void checkmate( Side side );
 }

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardCommander.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardCommander.java
@@ -44,4 +44,9 @@ interface WinboardCommander {
 	void onOfferDraw( OfferDrawListener listener );
 
 	void onResign( ResignListener listener );
+
+	/**
+	 * Inform Winboard that opponent has won
+	 */
+	void opponentWon();
 }

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
@@ -71,7 +71,6 @@ class WinboardCommanderImpl implements WinboardCommander {
 		//"For the actual move text from your chess engine (in place of MOVE above), your move should be either
 		//in coordinate notation (e.g., e2e4, e7e8q) with castling indicated by the King's two-square move (e.g., e1g1)"
 		this.communicator.send( "move " + move );
-		communicator.send( "0-1 {LeokomChess reason}" );
 	}
 
 	@Override
@@ -117,6 +116,11 @@ class WinboardCommanderImpl implements WinboardCommander {
 		//"If you won but did not just play a mate, your opponent must have resigned or forfeited."
 
 		listenersWithoutParams.put( "result 1-0 {Black resigns}", listener );
+	}
+
+	@Override
+	public void opponentWon() {
+		communicator.send( "0-1 {LeokomChess reason}" );
 	}
 
 	@Override

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
@@ -71,6 +71,7 @@ class WinboardCommanderImpl implements WinboardCommander {
 		//"For the actual move text from your chess engine (in place of MOVE above), your move should be either
 		//in coordinate notation (e.g., e2e4, e7e8q) with castling indicated by the King's two-square move (e.g., e1g1)"
 		this.communicator.send( "move " + move );
+		communicator.send( "0-1 {reason}" );
 	}
 
 	@Override

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
@@ -130,8 +130,11 @@ class WinboardCommanderImpl implements WinboardCommander {
 
 	@Override
 	public void processInputFromServer() {
-		//TODO: potential null from communicator is not processed yet
 		final String receivedCommand = communicator.receive();
+		//server might send nothing. No problems.
+		if ( receivedCommand == null ) {
+			return;
+		}
 
 		for ( String command : listenersWithoutParams.keySet() ) {
 			if ( receivedCommand.equals( command ) ) {

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
@@ -1,5 +1,7 @@
 package com.leokom.chess.player.winboard;
 
+import com.leokom.chess.engine.Side;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -119,8 +121,17 @@ class WinboardCommanderImpl implements WinboardCommander {
 	}
 
 	@Override
-	public void opponentWon() {
-		communicator.send( "0-1 {LeokomChess reason}" );
+	public void checkmate( Side winningSide ) {
+		String prefix = "";
+		switch ( winningSide ) {
+			case WHITE:
+				prefix = "1-0";
+				break;
+			case BLACK:
+				prefix = "0-1";
+				break;
+		}
+		communicator.send( prefix + " {LeokomChess : checkmate}" );
 	}
 
 	@Override

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardCommanderImpl.java
@@ -71,7 +71,7 @@ class WinboardCommanderImpl implements WinboardCommander {
 		//"For the actual move text from your chess engine (in place of MOVE above), your move should be either
 		//in coordinate notation (e.g., e2e4, e7e8q) with castling indicated by the King's two-square move (e.g., e1g1)"
 		this.communicator.send( "move " + move );
-		communicator.send( "0-1 {reason}" );
+		communicator.send( "0-1 {LeokomChess reason}" );
 	}
 
 	@Override

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -160,6 +160,13 @@ public class WinboardPlayer implements Player {
 		return needQuit;
 	}
 
+	//currently : for tests to prevent infinite loop
+	//for future: maybe Resign/Win/Draw or other termination of game
+	//should lead to quit as well?
+	void applyShuttingDown() {
+		needQuit = true;
+	}
+
 	private class WinboardUserMoveListener implements UserMoveListener {
 
 		/**

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -137,7 +137,6 @@ public class WinboardPlayer implements Player {
 		position = position.move( opponentMove );
 		commander.opponentMoved( translatedMove );
 
-		//TODO: position should return if it's winning etc
 		if ( position.isTerminal() ) {
 			commander.checkmate( position.getWinningSide() );
 		}
@@ -208,11 +207,16 @@ public class WinboardPlayer implements Player {
 
 			final Move engineMove = new Move( squareFrom, destination );
 			position = position.move( engineMove );
-			opponent.opponentMoved( engineMove );
 
 			if ( position.isTerminal() ) {
 				commander.checkmate( position.getWinningSide() );
 			}
+
+			//important to call last
+			//so that we'll won't return recursively here in another move
+			//the same we did in LegalPlayer : first update OUR state
+			//only THEN inform the opponent!
+			opponent.opponentMoved( engineMove );
 		}
 	}
 }

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -2,7 +2,6 @@ package com.leokom.chess.player.winboard;
 
 import com.leokom.chess.engine.Move;
 import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
 import com.leokom.chess.player.Player;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,9 +33,6 @@ public class WinboardPlayer implements Player {
 	//the 'state' of game should be commonly shared
 	//for both players
 	private Position position = Position.getInitialPosition();
-
-	//TODO: encapsulate 'side to move' into Position
-	private Side side = Side.WHITE;
 
 	//TODO: THINK about consequences of:
 	//creating several instances of the controller (must be singleton)
@@ -133,11 +129,10 @@ public class WinboardPlayer implements Player {
 		}
 
 		position = position.move( opponentMove );
-		side = side.opposite();
 		commander.opponentMoved( translatedMove );
 
 		//TODO: position should return if it's winning etc
-		if ( position.getMoves( side ).isEmpty() ) {
+		if ( position.getMoves().isEmpty() ) {
 			commander.opponentWon();
 		}
 	}
@@ -207,7 +202,6 @@ public class WinboardPlayer implements Player {
 
 			final Move engineMove = new Move( squareFrom, destination );
 			position = position.move( engineMove );
-			side = side.opposite();
 			opponent.opponentMoved( engineMove );
 		}
 	}

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -2,6 +2,7 @@ package com.leokom.chess.player.winboard;
 
 import com.leokom.chess.engine.Move;
 import com.leokom.chess.engine.Position;
+import com.leokom.chess.engine.Side;
 import com.leokom.chess.player.Player;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -139,7 +140,7 @@ public class WinboardPlayer implements Player {
 
 		//TODO: position should return if it's winning etc
 		if ( position.getMoves().isEmpty() ) {
-			commander.opponentWon();
+			commander.checkmate( Side.BLACK );
 		}
 	}
 
@@ -209,6 +210,10 @@ public class WinboardPlayer implements Player {
 			final Move engineMove = new Move( squareFrom, destination );
 			position = position.move( engineMove );
 			opponent.opponentMoved( engineMove );
+
+			if ( position.getMoves().isEmpty() ) {
+				commander.checkmate( Side.WHITE );
+			}
 		}
 	}
 }

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -139,6 +139,13 @@ public class WinboardPlayer implements Player {
 		position = position.move( opponentMove );
 		commander.opponentMoved( translatedMove );
 
+		detectTerminalPosition();
+	}
+
+	/**
+	 * Inform Winboard UI if position is terminal
+	 */
+	private void detectTerminalPosition() {
 		if ( position.isTerminal() ) {
 			commander.checkmate( position.getWinningSide() );
 		}
@@ -203,9 +210,7 @@ public class WinboardPlayer implements Player {
 			final Move engineMove = new Move( squareFrom, destination );
 			position = position.move( engineMove );
 
-			if ( position.isTerminal() ) {
-				commander.checkmate( position.getWinningSide() );
-			}
+			detectTerminalPosition();
 
 			//important to call last
 			//so that we'll won't return recursively here in another move

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -53,6 +53,8 @@ public class WinboardPlayer implements Player {
 
 		commander.onXBoard( () -> logger.info( "Ready to work" ) );
 
+		//maybe Resign/Win/Draw or other termination of game
+		//should lead to quit as well?
 		commander.onQuit( () -> needQuit = true );
 
 		commander.onUserMove( new WinboardUserMoveListener() );
@@ -175,13 +177,6 @@ public class WinboardPlayer implements Player {
 	 */
 	boolean needShuttingDown() {
 		return needQuit;
-	}
-
-	//currently : for tests to prevent infinite loop
-	//for future: maybe Resign/Win/Draw or other termination of game
-	//should lead to quit as well?
-	void applyShuttingDown() {
-		needQuit = true;
 	}
 
 	private class WinboardUserMoveListener implements UserMoveListener {

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -48,7 +48,7 @@ public class WinboardPlayer implements Player {
 	 * Create instance on Winboard controller.
 	 * @param winboardCommander instance of mid-level winboard-commander.
 	 */
-	private WinboardPlayer( WinboardCommander winboardCommander ) {
+	WinboardPlayer( WinboardCommander winboardCommander ) {
 		this.commander = winboardCommander;
 
 		commander.onXBoard( () -> logger.info( "Ready to work" ) );

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -29,6 +29,12 @@ public class WinboardPlayer implements Player {
 	private boolean needQuit = false;
 	private Player opponent;
 
+
+	//just for tests
+	void setPosition( Position position ) {
+		this.position = position;
+	}
+
 	//TODO: symptom of need to change architecture
 	//the 'state' of game should be commonly shared
 	//for both players

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -2,7 +2,6 @@ package com.leokom.chess.player.winboard;
 
 import com.leokom.chess.engine.Move;
 import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
 import com.leokom.chess.player.Player;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -139,8 +138,8 @@ public class WinboardPlayer implements Player {
 		commander.opponentMoved( translatedMove );
 
 		//TODO: position should return if it's winning etc
-		if ( position.getMoves().isEmpty() ) {
-			commander.checkmate( Side.BLACK );
+		if ( position.isTerminal() ) {
+			commander.checkmate( position.getWinningSide() );
 		}
 	}
 
@@ -211,8 +210,8 @@ public class WinboardPlayer implements Player {
 			position = position.move( engineMove );
 			opponent.opponentMoved( engineMove );
 
-			if ( position.getMoves().isEmpty() ) {
-				commander.checkmate( Side.WHITE );
+			if ( position.isTerminal() ) {
+				commander.checkmate( position.getWinningSide() );
 			}
 		}
 	}

--- a/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
+++ b/src/main/java/com/leokom/chess/player/winboard/WinboardPlayer.java
@@ -48,7 +48,7 @@ public class WinboardPlayer implements Player {
 	 * Create instance on Winboard controller.
 	 * @param winboardCommander instance of mid-level winboard-commander.
 	 */
-	WinboardPlayer( WinboardCommander winboardCommander ) {
+	private WinboardPlayer( WinboardCommander winboardCommander ) {
 		this.commander = winboardCommander;
 
 		commander.onXBoard( () -> logger.info( "Ready to work" ) );

--- a/src/test/java/com/leokom/chess/engine/BishopAllowedMovesTest.java
+++ b/src/test/java/com/leokom/chess/engine/BishopAllowedMovesTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class BishopAllowedMovesTest {
 	@Test
 	public void simpleDiagonal() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.BISHOP );
 
 		PositionAsserts.assertAllowedMoves(
@@ -19,7 +19,7 @@ public class BishopAllowedMovesTest {
 
 	@Test
 	public void fromB1() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "b1", PieceType.BISHOP );
 
 		PositionAsserts.assertAllowedMoves(
@@ -29,7 +29,7 @@ public class BishopAllowedMovesTest {
 
 	@Test
 	public void centralPoint() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "d4", PieceType.BISHOP );
 
 		PositionAsserts.assertAllowedMoves(
@@ -40,7 +40,7 @@ public class BishopAllowedMovesTest {
 
 	@Test
 	public void cannotMoveOverIntervening() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.BISHOP );
 
 		position.add( Side.WHITE, "c3", PieceType.KNIGHT ); //any
@@ -52,7 +52,7 @@ public class BishopAllowedMovesTest {
 
 	@Test
 	public void canCapture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.BISHOP );
 
 		position.add( Side.BLACK, "c3", PieceType.KNIGHT ); //any

--- a/src/test/java/com/leokom/chess/engine/BishopNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/BishopNewPositionTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertTrue;
 public class BishopNewPositionTest {
 	@Test
 	public void moveBishop() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.addPawn( Side.WHITE, "a1" );
 		position.add( Side.BLACK, "h8", PieceType.BISHOP );
 

--- a/src/test/java/com/leokom/chess/engine/CheckTest.java
+++ b/src/test/java/com/leokom/chess/engine/CheckTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 public class CheckTest {
 	@Test
 	public void cannotExposeKingToCheck() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 
 		position.add( Side.WHITE, "a1", PieceType.KING );
 		position.add( Side.WHITE, "a2", PieceType.ROOK );
@@ -31,7 +31,7 @@ public class CheckTest {
 	//'not attacked by one or more... opponent's pieces'
 	@Test
 	public void cannotExposeKingToOpponentKingAttack() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 
 		position.add( Side.WHITE, "a1", PieceType.KING );
 		position.add( Side.BLACK, "a3", PieceType.KING );
@@ -41,7 +41,7 @@ public class CheckTest {
 
 	@Test
 	public void cannotExposeKingToCheckTriangulate() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 
 		position.add( Side.WHITE, "a1", PieceType.KING );
 		position.add( Side.WHITE, "a2", PieceType.BISHOP );
@@ -54,7 +54,7 @@ public class CheckTest {
 
 	@Test
 	public void promotionCannotExposeKingToCheck() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 
 		position.add( Side.BLACK, "h2", PieceType.KING );
 		position.add( Side.BLACK, "f2", PieceType.PAWN );
@@ -67,14 +67,14 @@ public class CheckTest {
 	//more integration test - checking whole board moves
 	@Test
 	public void cannotLeaveKingInCheck() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 
 		position.add( Side.BLACK, "h2", PieceType.KING );
 		position.add( Side.WHITE, "g2", PieceType.QUEEN );
 		position.add( Side.BLACK, "a1", PieceType.QUEEN );
 
 
-		final Set<Move> moves = position.getMoves( Side.BLACK );
+		final Set<Move> moves = position.getMoves();
 		assertEquals( 1, moves.size() );
 		final Move singleMove = moves.iterator().next();
 		assertEquals( "h2", singleMove.getFrom() );
@@ -84,7 +84,7 @@ public class CheckTest {
 	//even if such pieces are constrained from moving to that square because they would then leave or place their own king in check
 	@Test
 	public void checkEvenIfCannotMove() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 
 		position.add( Side.WHITE, "a1", PieceType.KING );
 		position.add( Side.WHITE, "a3", PieceType.ROOK );

--- a/src/test/java/com/leokom/chess/engine/CheckTest.java
+++ b/src/test/java/com/leokom/chess/engine/CheckTest.java
@@ -27,6 +27,18 @@ public class CheckTest {
 		assertAllowedMoves( position, "a2", "a3" ); //cannot move horizontally
 	}
 
+	//simple test to ensure 3.8 a) is fully covered
+	//'not attacked by one or more... opponent's pieces'
+	@Test
+	public void cannotExposeKingToOpponentKingAttack() {
+		Position position = new Position();
+
+		position.add( Side.WHITE, "a1", PieceType.KING );
+		position.add( Side.BLACK, "a3", PieceType.KING );
+
+		assertAllowedMoves( position, "a1", "b1" );
+	}
+
 	@Test
 	public void cannotExposeKingToCheckTriangulate() {
 		Position position = new Position();

--- a/src/test/java/com/leokom/chess/engine/CheckmateTest.java
+++ b/src/test/java/com/leokom/chess/engine/CheckmateTest.java
@@ -10,13 +10,13 @@ import org.junit.Test;
 public class CheckmateTest {
 	@Test
 	public void noMoreMovesAfterCheckmate() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "h3", PieceType.QUEEN );
 		position.add( Side.WHITE, "c1", PieceType.KING );
 		position.add( Side.BLACK, "a1", PieceType.KING );
 
 		final Position matePosition = position.move( new Move( "h3", "a3" ) );
 
-		Assert.assertTrue( matePosition.getMoves( Side.BLACK ).isEmpty() );
+		Assert.assertTrue( matePosition.getMoves().isEmpty() );
 	}
 }

--- a/src/test/java/com/leokom/chess/engine/CheckmateTest.java
+++ b/src/test/java/com/leokom/chess/engine/CheckmateTest.java
@@ -1,8 +1,7 @@
 package com.leokom.chess.engine;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import static junit.framework.Assert.assertTrue;
 
 /**
  * Author: Leonid
@@ -18,6 +17,6 @@ public class CheckmateTest {
 
 		final Position matePosition = position.move( new Move( "h3", "a3" ) );
 
-		assertTrue( matePosition.getMoves( Side.BLACK ).isEmpty() );
+		Assert.assertTrue( matePosition.getMoves( Side.BLACK ).isEmpty() );
 	}
 }

--- a/src/test/java/com/leokom/chess/engine/CheckmateTest.java
+++ b/src/test/java/com/leokom/chess/engine/CheckmateTest.java
@@ -1,0 +1,23 @@
+package com.leokom.chess.engine;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Author: Leonid
+ * Date-time: 08.02.15 18:27
+ */
+public class CheckmateTest {
+	@Test
+	public void noMoreMovesAfterCheckmate() {
+		Position position = new Position();
+		position.add( Side.WHITE, "h3", PieceType.QUEEN );
+		position.add( Side.WHITE, "c1", PieceType.KING );
+		position.add( Side.BLACK, "a1", PieceType.KING );
+
+		final Position matePosition = position.move( new Move( "h3", "a3" ) );
+
+		assertTrue( matePosition.getMoves( Side.BLACK ).isEmpty() );
+	}
+}

--- a/src/test/java/com/leokom/chess/engine/KingAllowedMovesCannotMoveOnAttackedSquareTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingAllowedMovesCannotMoveOnAttackedSquareTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 	@Test
 	public void withPawnNotPromotion() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( Side.WHITE, "a2" ); //attacks b3
 		position.add( Side.BLACK, "a3", PieceType.KING );
 
@@ -23,7 +23,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void withPawnPromotion() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( Side.BLACK, "h2" ); //may be promoted to h1 or capture g1
 		position.add( Side.WHITE, "f1", PieceType.KING );
 
@@ -34,7 +34,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void knightAttacked() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "c3", PieceType.KNIGHT ); //controls b1, a2
 
 		position.add( Side.WHITE, "a1", PieceType.KING );
@@ -46,7 +46,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void ourSideKnightIsNotAttacker() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "c3", PieceType.KNIGHT ); //controls b1, a2
 
 		position.add( Side.WHITE, "a1", PieceType.KING );
@@ -58,7 +58,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void knightAndPawnAttack() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "c3", PieceType.KNIGHT ); //controls b1, a2
 		position.add( Side.BLACK, "a2", PieceType.PAWN ); //controls b1
 
@@ -71,7 +71,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void knightAndPawnAttackNoWay() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "c3", PieceType.KNIGHT ); //controls b1, a2
 		position.add( Side.BLACK, "a3", PieceType.PAWN ); //controls b2
 
@@ -83,7 +83,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void cannotCaptureIfControlledByPawn() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g7", PieceType.PAWN );
 		position.add( Side.WHITE, "h6", PieceType.PAWN ); //protects the pawn
 
@@ -96,7 +96,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void canCaptureAPawnThatControlsOtherPiece() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g8", PieceType.KNIGHT );
 		position.add( Side.WHITE, "h7", PieceType.PAWN ); //protects the knight
 
@@ -109,10 +109,8 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void bishopProtected() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "c3", PieceType.BISHOP ); //controls b2, a1
-
-
 		position.add( Side.BLACK, "a2", PieceType.KING );
 
 		PositionAsserts.assertAllowedMoves(
@@ -122,11 +120,9 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void bishopProtectedCannotCapture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "c3", PieceType.BISHOP ); //controls b2, a1
 		position.add( Side.WHITE, "a1", PieceType.BISHOP ); //controls b2, a1
-
-
 		position.add( Side.BLACK, "a2", PieceType.KING );
 
 		PositionAsserts.assertAllowedMoves(
@@ -136,9 +132,8 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void rookControl() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "b3", PieceType.ROOK ); //controls file b, rank 3
-
 		position.add( Side.BLACK, "a1", PieceType.KING );
 
 		PositionAsserts.assertAllowedMoves(
@@ -148,7 +143,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void rookProtectsOwnPiece() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "c2", PieceType.ROOK );
 		position.add( Side.WHITE, "a2", PieceType.PAWN );
 
@@ -164,7 +159,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 	//but now it's attacked. FIDE rules have some ambiguity in 3.8 (solved completely in 3.9)
 	@Test
 	public void integrationOfRookAndPawn() {  //they greatly reduce king's possibilities
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g8", PieceType.ROOK );
 		position.add( Side.WHITE, "h7", PieceType.PAWN ); //protects the rook
 
@@ -177,7 +172,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void bishopAttackFromCheckToCheck() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "f6", PieceType.BISHOP );
 
 		position.add( Side.BLACK, "h8", PieceType.KING );
@@ -189,7 +184,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void bishopAttackFromCheckToCheckCanCapture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "f6", PieceType.BISHOP );
 
 		position.add( Side.BLACK, "g7", PieceType.KING );
@@ -201,7 +196,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void queenAttacked() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "f6", PieceType.QUEEN );
 
 		position.add( Side.BLACK, "h8", PieceType.KING );
@@ -213,7 +208,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void queenAttackedVertically() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g5", PieceType.QUEEN );
 
 		position.add( Side.BLACK, "h8", PieceType.KING );
@@ -225,7 +220,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void queenProtectsFromCapture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g5", PieceType.QUEEN );
 		position.add( Side.WHITE, "g8", PieceType.KNIGHT ); //protected
 
@@ -238,7 +233,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void queenProtectsFromCaptureNoWayForKing() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g6", PieceType.QUEEN );
 		position.add( Side.WHITE, "g8", PieceType.KNIGHT ); //protected
 
@@ -251,7 +246,7 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void ownQueenIsNotAProblem() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g8", PieceType.KNIGHT );
 
 		position.add( Side.BLACK, "g6", PieceType.QUEEN ); //own queen
@@ -265,12 +260,10 @@ public class KingAllowedMovesCannotMoveOnAttackedSquareTest {
 
 	@Test
 	public void kingCannotMeetAKing() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.KING );
 
 		position.add( Side.BLACK, "c1", PieceType.KING );
-
-
 
 		PositionAsserts.assertAllowedMoves(
 				position, "a1",

--- a/src/test/java/com/leokom/chess/engine/KingAllowedMovesCastlingTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingAllowedMovesCastlingTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class KingAllowedMovesCastlingTest {
 	@Test
 	public void castlingIsAllowed() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
@@ -20,7 +20,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void castlingIsAllowedBlack() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "e8", PieceType.KING );
 
 		position.add( Side.BLACK, "h8", PieceType.ROOK );
@@ -31,7 +31,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void castlingQueenSide() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "e8", PieceType.KING );
 
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
@@ -42,13 +42,12 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void rightToCastlingIsLostIfKingMoved() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
-
 		position.add( Side.BLACK, "a8", PieceType.KING );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 			.move( "e1", "e2" )
 			.move( "a8", "a7" ) //any valid black move
 			.move( "e2", "e1" )
@@ -60,14 +59,14 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void rightToCastlingNoInfluenceToOppositeSide() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 				.move( "e1", "g1" ); //castling
 
 		PositionAsserts.assertAllowedMovesInclude(
@@ -76,14 +75,14 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test //not just one move lost
 	public void rightToCastlingIsLostPermanently() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 		position.add( Side.WHITE, "a2", PieceType.PAWN );
 
 		position.add( Side.BLACK, "a8", PieceType.KING );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 				.move( "e1", "e2" )
 				.move( "a8", "a7" ) //any valid black move
 				.move( "e2", "e1" )
@@ -97,14 +96,14 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test //not just one move lost
 	public void castlingIsImpossibleAfterCastling() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 		position.add( Side.WHITE, "a2", PieceType.PAWN );
 
 		position.add( Side.BLACK, "a8", PieceType.KING );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 				.move( "e1", "g1" ) //castle
 				.move( "a8", "a7" ) //any valid black move
 				.move( "f1", "f2" ) //rook movement started
@@ -124,14 +123,14 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void castlingRightLostIfRookMoved() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "h1", PieceType.KING );
 
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 				.move( "a8", "a7" )
 				.move( "h1", "h2" ); //any valid white move
 
@@ -141,14 +140,14 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void castlingRightLostPermanentlyIfRookMoved() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "h1", PieceType.KING );
 
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 			.move( "a8", "a7" )
 			.move( "h1", "h2" ) //any valid white move
 			.move( "a7", "a8" )
@@ -160,7 +159,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void castlingRightNotLostWithAnotherRook() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "h3", PieceType.PAWN );
 		position.add( Side.WHITE, "h1", PieceType.KING );
@@ -169,7 +168,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "h8", PieceType.ROOK );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 				.move( "a8", "a7" )
 				.move( "h1", "h2" ); //any valid white move
 
@@ -179,7 +178,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void bothRooksMovedCannotCastle() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "h3", PieceType.PAWN );
 		position.add( Side.WHITE, "h1", PieceType.KING );
@@ -188,7 +187,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "h8", PieceType.ROOK );
 
-		Position newPosition = position
+		Position newPosition = position.build()
 				.move( "a8", "a7" )
 				.move( "h1", "h2" )
 				.move( "h8", "h5" )
@@ -205,7 +204,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void preventTemporaryCastlingIfAttacked() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		//attacking the black king
 		position.add( Side.WHITE, "e1", PieceType.ROOK );
@@ -224,7 +223,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void checkIsJustTemporaryPrevention() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		//attacking the black king
 		position.add( Side.WHITE, "e1", PieceType.ROOK );
@@ -235,7 +234,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "h7", PieceType.ROOK );
 
 		//blocking check
-		Position newPosition = position
+		Position newPosition = position.build()
 				.move( "h7", "e7" )
 				.move( "e1", "e2" ); //non-check move
 
@@ -246,7 +245,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void preventCastlingIfCrossSquareAttacked() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		//attacking rank f
 		position.add( Side.WHITE, "f1", PieceType.ROOK );
@@ -266,7 +265,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void preventCastlingIfCrossSquareAttackedQueenSide() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		//attacking rank d
 		position.add( Side.WHITE, "d1", PieceType.QUEEN );
@@ -287,7 +286,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void cannotCastleIfExposeKingToCheck() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 
@@ -302,7 +301,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void ourPieceInMiddlePreventsCastling() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "a1", PieceType.ROOK );
 		position.add( Side.WHITE, "b1", PieceType.KNIGHT );
@@ -316,7 +315,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test
 	public void opponentPieceInMiddlePreventsCastling() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 
@@ -331,7 +330,7 @@ public class KingAllowedMovesCastlingTest {
 
 	@Test //cannot capture by castling
 	public void pieceAtCastlingTargetPrevents() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 

--- a/src/test/java/com/leokom/chess/engine/KingAllowedMovesCastlingTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingAllowedMovesCastlingTest.java
@@ -47,7 +47,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 		position.add( Side.BLACK, "a8", PieceType.KING );
 
-		Position newPosition = position.build()
+		Position newPosition = position
 			.move( "e1", "e2" )
 			.move( "a8", "a7" ) //any valid black move
 			.move( "e2", "e1" )
@@ -66,8 +66,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
-		Position newPosition = position.build()
-				.move( "e1", "g1" ); //castling
+		Position newPosition = position.move( "e1", "g1" ); //castling
 
 		PositionAsserts.assertAllowedMovesInclude(
 				newPosition, "e8", "c8" );
@@ -82,7 +81,7 @@ public class KingAllowedMovesCastlingTest {
 
 		position.add( Side.BLACK, "a8", PieceType.KING );
 
-		Position newPosition = position.build()
+		Position newPosition = position
 				.move( "e1", "e2" )
 				.move( "a8", "a7" ) //any valid black move
 				.move( "e2", "e1" )
@@ -103,7 +102,7 @@ public class KingAllowedMovesCastlingTest {
 
 		position.add( Side.BLACK, "a8", PieceType.KING );
 
-		Position newPosition = position.build()
+		Position newPosition = position
 				.move( "e1", "g1" ) //castle
 				.move( "a8", "a7" ) //any valid black move
 				.move( "f1", "f2" ) //rook movement started

--- a/src/test/java/com/leokom/chess/engine/KingAllowedMovesCastlingTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingAllowedMovesCastlingTest.java
@@ -130,7 +130,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
-		Position newPosition = position.build()
+		Position newPosition = position
 				.move( "a8", "a7" )
 				.move( "h1", "h2" ); //any valid white move
 
@@ -147,7 +147,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
-		Position newPosition = position.build()
+		Position newPosition = position.setSideOf( "a8" ).build()
 			.move( "a8", "a7" )
 			.move( "h1", "h2" ) //any valid white move
 			.move( "a7", "a8" )
@@ -168,7 +168,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "h8", PieceType.ROOK );
 
-		Position newPosition = position.build()
+		Position newPosition = position.setSideOf( "a8" ).build()
 				.move( "a8", "a7" )
 				.move( "h1", "h2" ); //any valid white move
 
@@ -187,7 +187,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "h8", PieceType.ROOK );
 
-		Position newPosition = position.build()
+		Position newPosition = position.setSideOf( "a8" ).build()
 				.move( "a8", "a7" )
 				.move( "h1", "h2" )
 				.move( "h8", "h5" )
@@ -234,7 +234,7 @@ public class KingAllowedMovesCastlingTest {
 		position.add( Side.BLACK, "h7", PieceType.ROOK );
 
 		//blocking check
-		Position newPosition = position.build()
+		Position newPosition = position.setSideOf( "h7" ).build()
 				.move( "h7", "e7" )
 				.move( "e1", "e2" ); //non-check move
 

--- a/src/test/java/com/leokom/chess/engine/KingAllowedMovesTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingAllowedMovesTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class KingAllowedMovesTest {
 	@Test
 	public void a1() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.KING );
 
 		PositionAsserts.assertAllowedMoves(
@@ -21,7 +21,7 @@ public class KingAllowedMovesTest {
 
 	@Test
 	public void h8() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "h8", PieceType.KING );
 
 		PositionAsserts.assertAllowedMoves(
@@ -33,7 +33,7 @@ public class KingAllowedMovesTest {
 
 	@Test
 	public void a8() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "a8", PieceType.KING );
 
 		PositionAsserts.assertAllowedMoves(
@@ -45,7 +45,7 @@ public class KingAllowedMovesTest {
 
 	@Test
 	public void e4() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "e4", PieceType.KING );
 
 		PositionAsserts.assertAllowedMoves(
@@ -59,7 +59,7 @@ public class KingAllowedMovesTest {
 
 	@Test
 	public void cannotMoveOnBlockedSquare() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.KING );
 
 		position.add( Side.WHITE, "b1", PieceType.QUEEN );
@@ -74,7 +74,7 @@ public class KingAllowedMovesTest {
 
 	@Test
 	public void canCapture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.KING );
 
 		position.add( Side.BLACK, "b1", PieceType.KNIGHT );

--- a/src/test/java/com/leokom/chess/engine/KingNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingNewPositionTest.java
@@ -13,7 +13,7 @@ public class KingNewPositionTest {
 		
 		position.add( Side.WHITE, "e1", PieceType.KING );
 
-		final Position newPosition = position.build().move( "e1", "d1" );
+		final Position newPosition = position.move( "e1", "d1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );
 		PositionAsserts.assertHasPiece( newPosition,PieceType.KING, Side.WHITE, "d1" );
 	}
@@ -88,7 +88,7 @@ public class KingNewPositionTest {
 		position.add( Side.WHITE, "f1", PieceType.KING );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.build().move( "f1", "g1" );
+		final Position newPosition = position.move( "f1", "g1" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.WHITE, "g1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );

--- a/src/test/java/com/leokom/chess/engine/KingNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingNewPositionTest.java
@@ -25,7 +25,7 @@ public class KingNewPositionTest {
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.BLACK, "d1", PieceType.QUEEN );
 
-		final Position newPosition = position.build().move( "e1", "d1" );
+		final Position newPosition = position.move( "e1", "d1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );
 		PositionAsserts.assertHasPiece( newPosition,PieceType.KING, Side.WHITE, "d1" );
 	}
@@ -38,7 +38,7 @@ public class KingNewPositionTest {
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.build().move( "e1", "g1" );
+		final Position newPosition = position.move( "e1", "g1" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.WHITE, "g1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );
@@ -55,7 +55,7 @@ public class KingNewPositionTest {
 		position.add( Side.BLACK, "h8", PieceType.ROOK );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.build().move( "e8", "g8" );
+		final Position newPosition = position.move( "e8", "g8" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.BLACK, "g8" );
 		PositionAsserts.assertEmptySquare( newPosition, "e8" );
@@ -72,7 +72,7 @@ public class KingNewPositionTest {
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.build().move( "e8", "c8" );
+		final Position newPosition = position.move( "e8", "c8" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.BLACK, "c8" );
 		PositionAsserts.assertEmptySquare( newPosition, "e8" );
@@ -104,7 +104,7 @@ public class KingNewPositionTest {
 		position.add( Side.WHITE, "a1", PieceType.ROOK );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.build().move( "e1", "c1" );
+		final Position newPosition = position.move( "e1", "c1" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.WHITE, "c1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );

--- a/src/test/java/com/leokom/chess/engine/KingNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/KingNewPositionTest.java
@@ -9,37 +9,36 @@ import org.junit.Test;
 public class KingNewPositionTest {
 	@Test
 	public void kingCanMove() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		
 		position.add( Side.WHITE, "e1", PieceType.KING );
 
-		final Position newPosition = position.move( "e1", "d1" );
+		final Position newPosition = position.build().move( "e1", "d1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );
 		PositionAsserts.assertHasPiece( newPosition,PieceType.KING, Side.WHITE, "d1" );
 	}
 
 	@Test
 	public void capture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.BLACK, "d1", PieceType.QUEEN );
 
-		final Position newPosition = position.move( "e1", "d1" );
+		final Position newPosition = position.build().move( "e1", "d1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );
 		PositionAsserts.assertHasPiece( newPosition,PieceType.KING, Side.WHITE, "d1" );
 	}
 
 	@Test
 	public void whiteShortCastling() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 
-		//TODO: do we need special second argument for castling?
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.move( "e1", "g1" );
+		final Position newPosition = position.build().move( "e1", "g1" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.WHITE, "g1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );
@@ -50,13 +49,13 @@ public class KingNewPositionTest {
 
 	@Test
 	public void blackCastlingKingSide() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "h8", PieceType.ROOK );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.move( "e8", "g8" );
+		final Position newPosition = position.build().move( "e8", "g8" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.BLACK, "g8" );
 		PositionAsserts.assertEmptySquare( newPosition, "e8" );
@@ -67,13 +66,13 @@ public class KingNewPositionTest {
 
 	@Test
 	public void blackCastlingQueenSide() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.BLACK, "e8", PieceType.KING );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.move( "e8", "c8" );
+		final Position newPosition = position.build().move( "e8", "c8" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.BLACK, "c8" );
 		PositionAsserts.assertEmptySquare( newPosition, "e8" );
@@ -84,12 +83,12 @@ public class KingNewPositionTest {
 
 	@Test
 	public void whitef1g1NonCastling() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "f1", PieceType.KING );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.move( "f1", "g1" );
+		final Position newPosition = position.build().move( "f1", "g1" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.WHITE, "g1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );
@@ -99,13 +98,13 @@ public class KingNewPositionTest {
 
 	@Test
 	public void whiteLongCastling() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "a1", PieceType.ROOK );
 
 		//target of King is unambiguously defining the type of its move
-		final Position newPosition = position.move( "e1", "c1" );
+		final Position newPosition = position.build().move( "e1", "c1" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KING, Side.WHITE, "c1" );
 		PositionAsserts.assertEmptySquare( newPosition, "e1" );

--- a/src/test/java/com/leokom/chess/engine/KnightAllowedMovesTest.java
+++ b/src/test/java/com/leokom/chess/engine/KnightAllowedMovesTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class KnightAllowedMovesTest {
 	@Test
 	public void knightMovesSquare() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.KNIGHT );
 
 		PositionAsserts.assertAllowedMoves(
@@ -18,7 +18,7 @@ public class KnightAllowedMovesTest {
 
 	@Test
 	public void cannotMoveIfOccupiedByMyColour() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.KNIGHT );
 
 		position.add( Side.WHITE, "b3", PieceType.PAWN ); //any!
@@ -29,7 +29,7 @@ public class KnightAllowedMovesTest {
 
 	@Test
 	public void cannotMoveIfOccupiedByMyColourTwo() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "a1", PieceType.KNIGHT );
 
 		position.add( Side.BLACK, "b3", PieceType.PAWN ); //any!
@@ -40,7 +40,7 @@ public class KnightAllowedMovesTest {
 
 	@Test
 	public void canCapture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "a1", PieceType.KNIGHT );
 
 		position.add( Side.WHITE, "b3", PieceType.PAWN ); //any except king
@@ -51,7 +51,7 @@ public class KnightAllowedMovesTest {
 
 	@Test
 	public void knightMovesAnotherSquare() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "h1", PieceType.KNIGHT );
 
 		PositionAsserts.assertAllowedMoves(
@@ -60,7 +60,7 @@ public class KnightAllowedMovesTest {
 
 	@Test
 	public void anotherRank() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a8", PieceType.KNIGHT );
 
 		PositionAsserts.assertAllowedMoves(
@@ -69,7 +69,7 @@ public class KnightAllowedMovesTest {
 
 	@Test
 	public void threeDestinations() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "b1", PieceType.KNIGHT );
 
 		PositionAsserts.assertAllowedMoves(
@@ -78,7 +78,7 @@ public class KnightAllowedMovesTest {
 
 	@Test
 	public void eightDestinations() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "f5", PieceType.KNIGHT );
 
 		PositionAsserts.assertAllowedMoves(

--- a/src/test/java/com/leokom/chess/engine/KnightNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/KnightNewPositionTest.java
@@ -12,10 +12,10 @@ import static org.junit.Assert.assertEquals;
 public class KnightNewPositionTest {
 	@Test
 	public void simpleMove() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "b1", PieceType.KNIGHT );
 
-		final Position newPosition = position.move( "b1", "c3" );
+		final Position newPosition = position.build().move( "b1", "c3" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KNIGHT, Side.WHITE, "c3" );
 
@@ -23,10 +23,11 @@ public class KnightNewPositionTest {
 
 	@Test
 	public void blackMove() {
-		Position position = new Position();
-		position.add( Side.BLACK, "b1", PieceType.KNIGHT );
+		PositionBuilder position = new PositionBuilder()
+			.add( Side.BLACK, "b1", PieceType.KNIGHT )
+				.setSideOf( "b1" );
 
-		final Position newPosition = position.move( "b1", "c3" );
+		final Position newPosition = position.build().move( "b1", "c3" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KNIGHT, Side.BLACK, "c3" );
 
@@ -34,11 +35,11 @@ public class KnightNewPositionTest {
 
 	@Test
 	public void otherPiecesRemain() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "b1", PieceType.KNIGHT );
 		position.add( Side.BLACK, "a2", PieceType.PAWN );
 
-		final Position newPosition = position.move( "b1", "c3" );
+		final Position newPosition = position.setSideOf( "b1" ).build().move( "b1", "c3" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KNIGHT, Side.BLACK, "c3" );
 
@@ -48,10 +49,10 @@ public class KnightNewPositionTest {
 
 	@Test
 	public void movingKnightRemoved() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "b1", PieceType.KNIGHT );
 
-		final Position newPosition = position.move( "b1", "a3" );
+		final Position newPosition = position.setSideOf( "b1" ).build().move( "b1", "a3" );
 
 		PositionAsserts.assertEmptySquare( newPosition, "b1" );
 
@@ -59,12 +60,12 @@ public class KnightNewPositionTest {
 
 	@Test
 	public void enPassantPossibilityClearance() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "h1", PieceType.KNIGHT );
 
 		position.add( Side.WHITE, "a2", PieceType.PAWN );
 
-		Position afterPawnMove = position.move( "a2", "a4" );
+		Position afterPawnMove = position.setSideOf( "a2" ).build().move( "a2", "a4" );
 		//this assert is just to ensure previous conditions are ok
 		assertEquals( "a", afterPawnMove.getPossibleEnPassantFile() );
 

--- a/src/test/java/com/leokom/chess/engine/KnightNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/KnightNewPositionTest.java
@@ -15,7 +15,7 @@ public class KnightNewPositionTest {
 		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "b1", PieceType.KNIGHT );
 
-		final Position newPosition = position.build().move( "b1", "c3" );
+		final Position newPosition = position.move( "b1", "c3" );
 
 		PositionAsserts.assertHasPiece( newPosition, PieceType.KNIGHT, Side.WHITE, "c3" );
 

--- a/src/test/java/com/leokom/chess/engine/PawnAllowedMovesEnPassantTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnAllowedMovesEnPassantTest.java
@@ -17,7 +17,7 @@ public class PawnAllowedMovesEnPassantTest {
 	*/
 	@Test
 	public void noEnPassantInSimilarPosition() {
-		Position position = createPositionWithoutEnPassantRight();
+		PositionBuilder position = createPositionWithoutEnPassantRight();
 
 		position.addPawn( Side.BLACK, "f5" );
 
@@ -26,7 +26,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void noEnPassantInSimilarPositionBlack() {
-		Position position = createPositionWithoutEnPassantRight();
+		PositionBuilder position = createPositionWithoutEnPassantRight();
 		position.addPawn( Side.WHITE, "c4" );
 
 		testPawn( position, "d4", Side.BLACK, "d3" );
@@ -35,7 +35,7 @@ public class PawnAllowedMovesEnPassantTest {
 	//both sides are on e, black had double move last
 	@Test
 	public void noEnPassantInSymmetricCase() {
-		Position position = createPositionWithEnPassantPossibility( "e" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "e" );
 		position.addPawn( Side.WHITE, "e4" );
 		position.addPawn( Side.BLACK, "e5" );
 
@@ -44,7 +44,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void twoSidedEnPassant() {
-		Position position = createPositionWithEnPassantPossibility( "c" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "c" );
 		position.addPawn( Side.BLACK, "c5" );
 
 		position.addPawn( Side.WHITE, "b5" );
@@ -56,7 +56,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void noEnPassantSymmetricWhite() {
-		Position position = createPositionWithEnPassantPossibility( "a" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "a" );
 		position.addPawn( Side.WHITE, "a4" );
 		position.addPawn( Side.BLACK, "a5" );
 
@@ -65,7 +65,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void enPassantInActionLeftSideCaptureBlack() {
-		Position position = createPositionWithEnPassantPossibility( "c" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "c" );
 		position.addPawn( Side.WHITE, "c4" );
 
 		testPawn( position, "d4", Side.BLACK, "d3", "c3" );
@@ -73,7 +73,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void enPassantInActionRightSideCaptureBlack() {
-		Position position = createPositionWithEnPassantPossibility( "g" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "g" );
 		position.addPawn( Side.WHITE, "g4" );
 
 		testPawn( position, "f4", Side.BLACK, "f3", "g3" );
@@ -81,7 +81,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void enPassantInActionRightSideCapture() {
-		Position position = createPositionWithEnPassantPossibility( "f" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "f" );
 
 		position.addPawn( Side.BLACK, "f5" );
 
@@ -91,7 +91,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void enPassantInActionLeftSideCapture() {
-		Position position = createPositionWithEnPassantPossibility( "c" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "c" );
 
 		position.addPawn( Side.BLACK, "c5" );
 
@@ -100,7 +100,7 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void enPassantInActionRightSideCaptureAnother() {
-		Position position = createPositionWithEnPassantPossibility( "g" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "g" );
 
 		position.addPawn( Side.BLACK, "g5" );
 
@@ -109,14 +109,14 @@ public class PawnAllowedMovesEnPassantTest {
 
 	@Test
 	public void enPassantInActionButNotWorksOnDifferentRank() {
-		Position position = createPositionWithEnPassantPossibility( "c" );
+		PositionBuilder position = createPositionWithEnPassantPossibility( "c" );
 		position.addPawn( Side.BLACK, "c5" );
 
 		testPawn( position, "f5", Side.WHITE, "f6" );
 	}
 
-	private static Position createPositionWithoutEnPassantRight() {
-		return new Position();
+	private static PositionBuilder createPositionWithoutEnPassantRight() {
+		return new PositionBuilder();
 	}
 
 	/**
@@ -126,8 +126,8 @@ public class PawnAllowedMovesEnPassantTest {
 	 * @param file
 	 * @return
 	 */
-	private static Position createPositionWithEnPassantPossibility( String file ) {
-		final Position position = new Position();
+	private static PositionBuilder createPositionWithEnPassantPossibility( String file ) {
+		final PositionBuilder position = new PositionBuilder();
 		position.setEnPassantFile( file );
 		return position;
 	}

--- a/src/test/java/com/leokom/chess/engine/PawnAllowedMovesMultiplePositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnAllowedMovesMultiplePositionTest.java
@@ -20,7 +20,7 @@ public class PawnAllowedMovesMultiplePositionTest {
 	public void blackPawn7rank() {
 		//TODO: do we have guarantee characters are ordered alphabetically?
 		for( char file = 'a'; file <= 'h'; file++ ) {
-			Position position = new Position();
+			PositionBuilder position = new PositionBuilder();
 			testPawn( position, file + "7", Side.BLACK, file + "6", file + "5" );
 		}
 	}
@@ -35,7 +35,7 @@ public class PawnAllowedMovesMultiplePositionTest {
 			//2 is source of promotion rules (so we'll test it separately)
 			//7 -> 2 destinations.
 			for ( int rank = 3; rank <= 6; rank++ ) {
-				Position position = new Position();
+				PositionBuilder position = new PositionBuilder();
 				final String sourceRank = String.valueOf( rank );
 				final String expectedRank = String.valueOf( rank - 1 );
 

--- a/src/test/java/com/leokom/chess/engine/PawnAllowedMovesTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnAllowedMovesTest.java
@@ -12,11 +12,11 @@ import static com.leokom.chess.engine.PositionUtils.addCapturable;
  * Date-time: 21.08.12 15:55
  */
 public class PawnAllowedMovesTest {
-	private Position position;
+	private PositionBuilder position;
 
 	@Before
 	public void prepare() {
-		position = new Position();
+		position = new PositionBuilder();
 	}
 
 	/**

--- a/src/test/java/com/leokom/chess/engine/PawnEnPassantNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnEnPassantNewPositionTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertNull;
 public class PawnEnPassantNewPositionTest {
 	@Test
 	public void enPassantLeft() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.setEnPassantFile( "d" );
 		position.addPawn( BLACK, "d5" );
 
@@ -32,7 +32,7 @@ public class PawnEnPassantNewPositionTest {
 
 	@Test
 	public void enPassantLeftTriangle() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.setEnPassantFile( "e" );
 
 		position.addPawn( BLACK, "e5" );
@@ -51,7 +51,7 @@ public class PawnEnPassantNewPositionTest {
 
 	@Test
 	public void right() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.setEnPassantFile( "g" );
 		position.addPawn( BLACK, "g5" );
 
@@ -69,7 +69,7 @@ public class PawnEnPassantNewPositionTest {
 
 	@Test
 	public void enPassantBlackLeft() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.setEnPassantFile( "a" );
 		position.addPawn( WHITE, "a4" );
 
@@ -83,7 +83,7 @@ public class PawnEnPassantNewPositionTest {
 
 	@Test
 	public void enPassantBlackTriangulate() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.setEnPassantFile( "g" );
 		position.addPawn( WHITE, "g4" );
 
@@ -97,7 +97,7 @@ public class PawnEnPassantNewPositionTest {
 
 	@Test
 	public void enPassantRightBlack() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.setEnPassantFile( "c" );
 		position.addPawn( WHITE, "c4" );
 

--- a/src/test/java/com/leokom/chess/engine/PawnNewPositionsTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnNewPositionsTest.java
@@ -15,11 +15,11 @@ import static org.junit.Assert.assertNotSame;
  * Date-time: 31.08.12 22:05
  */
 public class PawnNewPositionsTest {
-	private Position position;
+	private PositionBuilder position;
 
 	@Before
 	public void prepare() {
-		position = new Position();
+		position = new PositionBuilder();
 	}
 
 	@Test
@@ -28,7 +28,7 @@ public class PawnNewPositionsTest {
 		final String anyValidSquareToMove = "g4";
 		position.addPawn( Side.WHITE, anyInitialSquare );
 
-		Position newPosition = position.move( anyInitialSquare, anyValidSquareToMove );
+		Position newPosition = position.build().move( anyInitialSquare, anyValidSquareToMove );
 		assertNotNull( "New position must be not null", newPosition );
 		assertNotSame( newPosition, position );
 	}
@@ -154,7 +154,7 @@ public class PawnNewPositionsTest {
 		position.addPawn( movingSide, sourceSquare );
 		addCapturable( position, sideToCapture, targetSquare );
 
-		Position newPosition = position.move( sourceSquare, targetSquare );
+		Position newPosition = position.setSideOf( sourceSquare ).build().move( sourceSquare, targetSquare );
 		assertHasPawn( newPosition, targetSquare, movingSide );
 		assertEmptySquare( newPosition, sourceSquare );
 	}
@@ -170,8 +170,8 @@ public class PawnNewPositionsTest {
 	 * @return newPosition for further asserts
 	 */
 	private Position assertPawnMovement( Side side, String initialSquare, String squareToMove ) {
-		position.addPawn( side, initialSquare );
-		Position newPosition = position.move( initialSquare, squareToMove );
+		position.addPawn( side, initialSquare ).setSideOf( initialSquare );
+		Position newPosition = position.build().move( initialSquare, squareToMove );
 
 		assertHasPawn( newPosition, squareToMove, side );
 		assertEmptySquare( newPosition, initialSquare );

--- a/src/test/java/com/leokom/chess/engine/PawnNewPositionsTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnNewPositionsTest.java
@@ -28,7 +28,7 @@ public class PawnNewPositionsTest {
 		final String anyValidSquareToMove = "g4";
 		position.addPawn( Side.WHITE, anyInitialSquare );
 
-		Position newPosition = position.build().move( anyInitialSquare, anyValidSquareToMove );
+		Position newPosition = position.move( anyInitialSquare, anyValidSquareToMove );
 		assertNotNull( "New position must be not null", newPosition );
 		assertNotSame( newPosition, position );
 	}

--- a/src/test/java/com/leokom/chess/engine/PawnNewPositionsTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnNewPositionsTest.java
@@ -157,6 +157,7 @@ public class PawnNewPositionsTest {
 		Position newPosition = position.setSideOf( sourceSquare ).build().move( sourceSquare, targetSquare );
 		assertHasPawn( newPosition, targetSquare, movingSide );
 		assertEmptySquare( newPosition, sourceSquare );
+		org.junit.Assert.assertEquals( movingSide.opposite(), newPosition.getSideToMove() );
 	}
 
 	/**
@@ -175,6 +176,7 @@ public class PawnNewPositionsTest {
 
 		assertHasPawn( newPosition, squareToMove, side );
 		assertEmptySquare( newPosition, initialSquare );
+		org.junit.Assert.assertEquals( side.opposite(), newPosition.getSideToMove() );
 		return newPosition;
 	}
 }

--- a/src/test/java/com/leokom/chess/engine/PawnPromoteNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnPromoteNewPositionTest.java
@@ -13,7 +13,7 @@ import static com.leokom.chess.engine.Side.WHITE;
 public class PawnPromoteNewPositionTest {
 	@Test
 	public void toQueen() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( WHITE, "c7" );
 
 		Position newPosition = position.move( "c7", "c8Q" );
@@ -23,7 +23,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void toQueenAnotherFile(){
-		Position position = new Position(); //any en passant...
+		PositionBuilder position = new PositionBuilder(); //any en passant...
 		position.addPawn( WHITE, "a7" );
 
 		Position newPosition = position.move( "a7", "a8Q" );

--- a/src/test/java/com/leokom/chess/engine/PawnPromoteNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/PawnPromoteNewPositionTest.java
@@ -34,7 +34,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void toQueenBlack() {
-		Position position = new Position(); //any en passant...
+		PositionBuilder position = new PositionBuilder(); //any en passant...
 		position.addPawn( BLACK, "b2" );
 
 		Position newPosition = position.move( "b2", "b1Q" );
@@ -45,7 +45,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void captureLeftSide() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( Side.WHITE, "h7" );
 
 		//the only piece I can capture of the opposite side on the 8'th rank
@@ -63,7 +63,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void promotionLeavesRestOfPositionUntouched() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( WHITE, "a7" );
 		position.addPawn( WHITE, "c5" );
 		position.addQueen( BLACK, "h4" );
@@ -78,7 +78,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void promoteToKnight() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( WHITE, "a7" );
 
 		Position newPosition = position.move( "a7", "a8N" );
@@ -89,7 +89,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void promoteToRook() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( BLACK, "g2" );
 
 		Position newPosition = position.move( "g2", "g1R" );
@@ -99,7 +99,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void promoteToBishop() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( BLACK, "c2" );
 
 		Position newPosition = position.move( "c2", "c1B" );
@@ -109,7 +109,7 @@ public class PawnPromoteNewPositionTest {
 
 	@Test
 	public void promoteWithCaptureToRook() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addPawn( WHITE, "g7" );
 		position.add( BLACK, "h8", PieceType.KNIGHT );
 

--- a/src/test/java/com/leokom/chess/engine/PawnUtils.java
+++ b/src/test/java/com/leokom/chess/engine/PawnUtils.java
@@ -20,4 +20,9 @@ final class PawnUtils {
 		position.addPawn( side, pawnPosition );
 		PositionAsserts.assertAllowedMoves( position, pawnPosition, allMoves );
 	}
+
+	static void testPawn( PositionBuilder positionBuilder, String pawnPosition, Side side, String... allMoves ) {
+		Position position = positionBuilder.addPawn( side, pawnPosition ).setSideOf( pawnPosition ).build();
+		PositionAsserts.assertAllowedMoves( position, pawnPosition, allMoves );
+	}
 }

--- a/src/test/java/com/leokom/chess/engine/PositionAllowedMovesTest.java
+++ b/src/test/java/com/leokom/chess/engine/PositionAllowedMovesTest.java
@@ -19,7 +19,7 @@ public class PositionAllowedMovesTest {
 	//even more - FIDE rules have an explicit statement about the king capture.
 	@Test
 	public void cannotCaptureKing() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "a1", PieceType.QUEEN );
 		position.add( Side.BLACK, "c1", PieceType.KING );
 
@@ -28,11 +28,11 @@ public class PositionAllowedMovesTest {
 
 	@Test
 	public void simplePositionSingleMove() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "a1", PieceType.KING );
 		position.add( Side.BLACK, "c1", PieceType.KING );
 
-		Set< Move > moves = position.getMoves( Side.WHITE );
+		Set< Move > moves = position.getMoves();
 
 		assertEquals( 1, moves.size() );
 		final Move move = moves.iterator().next();
@@ -41,11 +41,11 @@ public class PositionAllowedMovesTest {
 
 	@Test //same test as previous but changing colours
 	public void simplePositionTriangulateByColor() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.BLACK, "a1", PieceType.KING );
 		position.add( Side.WHITE, "c1", PieceType.KING );
 
-		Set< Move > moves = position.getMoves( Side.BLACK );
+		Set< Move > moves = position.getMoves();
 
 		assertEquals( 1, moves.size() );
 		final Move move = moves.iterator().next();
@@ -54,7 +54,7 @@ public class PositionAllowedMovesTest {
 
 	@Test
 	public void simplePositionNoMoves() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "a1", PieceType.KING );
 
 		position.add( Side.BLACK, "b1", PieceType.BISHOP ); //any?
@@ -62,7 +62,7 @@ public class PositionAllowedMovesTest {
 		position.add( Side.BLACK, "b2", PieceType.PAWN ); //any?
 		position.add( Side.BLACK, "c1", PieceType.KING );
 
-		Set< Move > moves = position.getMoves( Side.WHITE );
+		Set< Move > moves = position.getMoves();
 
 		assertEquals( 0, moves.size() );
 	}

--- a/src/test/java/com/leokom/chess/engine/PositionAsserts.java
+++ b/src/test/java/com/leokom/chess/engine/PositionAsserts.java
@@ -50,8 +50,12 @@ public final class PositionAsserts {
 
 	static void assertAllowedMoves( PositionBuilder positionBuilder, String initialField, String... expectedReachableSquares ) {
 		final Position position = positionBuilder.setSideOf( initialField ).build();
-		Set<String> squares = position.getMovesFrom( initialField );
-		assertEquals( new HashSet<>( Arrays.asList( expectedReachableSquares ) ), squares );
+		assertAllowedMoves( position, initialField, expectedReachableSquares );
+	}
+
+	static void assertAllowedMovesInclude( PositionBuilder positionBuilder, String initialField, String targetToBeIncluded ) {
+		final Position position = positionBuilder.setSideOf( initialField ).build();
+		assertAllowedMovesInclude( position, initialField, targetToBeIncluded );
 	}
 
 	/**
@@ -69,6 +73,11 @@ public final class PositionAsserts {
 		assertTrue(
 			"Allowed moves must include : " + targetToBeIncluded + "; actually: " + squares,
 			squares.contains( targetToBeIncluded ) );
+	}
+
+	static void assertAllowedMovesOmit( PositionBuilder positionBuilder, String initialField, String targetToBeIncluded ) {
+		final Position position = positionBuilder.setSideOf( initialField ).build();
+		assertAllowedMovesOmit( position, initialField, targetToBeIncluded );
 	}
 
 	static void assertAllowedMovesOmit( Position position, String initialField, String targetToBeIncluded ) {

--- a/src/test/java/com/leokom/chess/engine/PositionAsserts.java
+++ b/src/test/java/com/leokom/chess/engine/PositionAsserts.java
@@ -48,6 +48,12 @@ public final class PositionAsserts {
 		assertEquals( new HashSet<>( Arrays.asList( expectedReachableSquares ) ), squares );
 	}
 
+	static void assertAllowedMoves( PositionBuilder positionBuilder, String initialField, String... expectedReachableSquares ) {
+		final Position position = positionBuilder.setSideOf( initialField ).build();
+		Set<String> squares = position.getMovesFrom( initialField );
+		assertEquals( new HashSet<>( Arrays.asList( expectedReachableSquares ) ), squares );
+	}
+
 	/**
 	 * Check that inside the position
 	 * there are NO legal moves from the square

--- a/src/test/java/com/leokom/chess/engine/PositionEnPassantPossibilityCreationTest.java
+++ b/src/test/java/com/leokom/chess/engine/PositionEnPassantPossibilityCreationTest.java
@@ -12,12 +12,11 @@ import static org.junit.Assert.assertNull;
  * Date-time: 11.09.12 22:28
  */
 public class PositionEnPassantPossibilityCreationTest {
-	private Position position;
+	private PositionBuilder position;
 
 	@Before
 	public void prepare() {
-		//TODO: this null is not important, "a" - "h" are also perfectly legal
-		position = new Position();
+		position = new PositionBuilder();
 	}
 
 	@Test
@@ -87,13 +86,12 @@ public class PositionEnPassantPossibilityCreationTest {
 
 	@Test
 	public void flagIsNotPreservedNextMove() {
-		Position newPosition = new Position();
-		newPosition.setEnPassantFile( "e" );
-		newPosition.addPawn( Side.WHITE, "e4" );
+		position.setEnPassantFile( "e" );
+		position.addPawn( Side.WHITE, "e4" );
 
-		newPosition.addPawn( Side.BLACK, "c7" ); //any
+		position.addPawn( Side.BLACK, "c7" ); //any
 		//any not double-pawn move
-		Position result = newPosition.move( "c7", "c6" );
+		Position result = position.move( "c7", "c6" );
 		assertNull( result.getPossibleEnPassantFile() );
 	}
 

--- a/src/test/java/com/leokom/chess/engine/PositionHasPawnTest.java
+++ b/src/test/java/com/leokom/chess/engine/PositionHasPawnTest.java
@@ -16,7 +16,8 @@ public class PositionHasPawnTest {
 
 	@Before
 	public void prepare() {
-		position = new Position();
+		//side doesn't matter here, right?
+		position = new Position( Side.WHITE );
 	}
 
 	@Test

--- a/src/test/java/com/leokom/chess/engine/PositionImmutabilityTest.java
+++ b/src/test/java/com/leokom/chess/engine/PositionImmutabilityTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertNull;
 public class PositionImmutabilityTest {
 	@Test
 	public void positionAfterMoveNotModified() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "e2", PieceType.PAWN );
 		position.add( Side.WHITE, "d2", PieceType.PAWN );
 		position.add( Side.BLACK, "g2", PieceType.PAWN );
@@ -35,7 +35,7 @@ public class PositionImmutabilityTest {
 
 	@Test
 	public void positionEnPassantStatusClear() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "e2", PieceType.PAWN );
 		position.add( Side.WHITE, "d2", PieceType.PAWN );
 		position.add( Side.BLACK, "g2", PieceType.PAWN );
@@ -52,7 +52,7 @@ public class PositionImmutabilityTest {
 
 	@Test
 	public void positionEnPassantStatusSet() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.setEnPassantFile( "e" );
 		position.add( Side.WHITE, "e4", PieceType.PAWN );
 		position.add( Side.WHITE, "d2", PieceType.PAWN );

--- a/src/test/java/com/leokom/chess/engine/PositionSideTest.java
+++ b/src/test/java/com/leokom/chess/engine/PositionSideTest.java
@@ -1,0 +1,12 @@
+package com.leokom.chess.engine;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PositionSideTest {
+	@Test
+	public void initialSide() {
+		assertEquals( Side.WHITE, Position.getInitialPosition().getSideToMove() );
+	}
+}

--- a/src/test/java/com/leokom/chess/engine/PositionSideTest.java
+++ b/src/test/java/com/leokom/chess/engine/PositionSideTest.java
@@ -9,4 +9,9 @@ public class PositionSideTest {
 	public void initialSide() {
 		assertEquals( Side.WHITE, Position.getInitialPosition().getSideToMove() );
 	}
+
+	@Test
+	public void sideAfterMove() {
+		assertEquals( Side.BLACK, Position.getInitialPosition().move( new Move( "e2", "e4" ) ).getSideToMove() );
+	}
 }

--- a/src/test/java/com/leokom/chess/engine/PositionUtils.java
+++ b/src/test/java/com/leokom/chess/engine/PositionUtils.java
@@ -14,6 +14,10 @@ final class PositionUtils {
 		position.addPawn( side, square );
 	}
 
+	static void addCapturable( PositionBuilder position, Side side, String square ) {
+		position.addPawn( side, square );
+	}
+
 	//TODO: extend when we introduce new pieces!
 
 	/**
@@ -26,6 +30,11 @@ final class PositionUtils {
 	 * @param square
 	 */
 	static PieceType addAny( Position position, Side side, String square ) {
+		position.addPawn( side, square );
+		return PieceType.PAWN;
+	}
+
+	static PieceType addAny( PositionBuilder position, Side side, String square ) {
 		position.addPawn( side, square );
 		return PieceType.PAWN;
 	}

--- a/src/test/java/com/leokom/chess/engine/QueenAllowedMovesTest.java
+++ b/src/test/java/com/leokom/chess/engine/QueenAllowedMovesTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class QueenAllowedMovesTest {
 	@Test
 	public void h1() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addQueen( Side.BLACK, "h1" );
 
 		PositionAsserts.assertAllowedMoves(
@@ -21,7 +21,7 @@ public class QueenAllowedMovesTest {
 
 	@Test
 	public void centerBlocksAndCaptures() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addQueen( Side.WHITE, "c4" );
 
 		position.addQueen( Side.WHITE, "d4" );

--- a/src/test/java/com/leokom/chess/engine/QueenNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/QueenNewPositionTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class QueenNewPositionTest {
 	@Test
 	public void queenMove() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.addQueen( Side.BLACK, "a2" );
 
 		position.addPawn( Side.WHITE, "c4" );

--- a/src/test/java/com/leokom/chess/engine/RookAllowedMovesTest.java
+++ b/src/test/java/com/leokom/chess/engine/RookAllowedMovesTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class RookAllowedMovesTest {
 	@Test
 	public void a1() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.BLACK, "a1", PieceType.ROOK );
 
 		PositionAsserts.assertAllowedMoves(
@@ -21,7 +21,7 @@ public class RookAllowedMovesTest {
 
 	@Test
 	public void e4() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e4", PieceType.ROOK );
 
 		PositionAsserts.assertAllowedMoves(
@@ -33,7 +33,7 @@ public class RookAllowedMovesTest {
 
 	@Test
 	public void blockedPieces() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "a1", PieceType.ROOK );
 		position.add( Side.WHITE, "a3", PieceType.BISHOP ); //any
 
@@ -46,7 +46,7 @@ public class RookAllowedMovesTest {
 
 	@Test
 	public void blockAndCapture() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "b1", PieceType.ROOK );
 
 		position.add( Side.WHITE, "b2", PieceType.BISHOP ); //any -> block

--- a/src/test/java/com/leokom/chess/engine/RookNewPositionTest.java
+++ b/src/test/java/com/leokom/chess/engine/RookNewPositionTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertTrue;
 public class RookNewPositionTest {
 	@Test
 	public void moveRook() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.addQueen( Side.WHITE, "a1" );
 		position.add( Side.BLACK, "a8", PieceType.ROOK );
 

--- a/src/test/java/com/leokom/chess/player/legalMover/CastlingSafetyEvaluatorTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/CastlingSafetyEvaluatorTest.java
@@ -1,9 +1,6 @@
 package com.leokom.chess.player.legalMover;
 
-import com.leokom.chess.engine.Move;
-import com.leokom.chess.engine.PieceType;
-import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
+import com.leokom.chess.engine.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,7 +16,7 @@ public class CastlingSafetyEvaluatorTest {
 
 	@Test
 	public void shouldKingMovementNotGoodInitially() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
 		position.add( Side.WHITE, "c1", PieceType.BISHOP );
@@ -33,7 +30,7 @@ public class CastlingSafetyEvaluatorTest {
 
 	@Test
 	public void shouldRookMoveOKGivenCastlingDone() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "e1", PieceType.KING );
 		position.add( Side.WHITE, "h1", PieceType.ROOK );
@@ -55,7 +52,7 @@ public class CastlingSafetyEvaluatorTest {
 
 	@Test
 	public void noProblemToMoveKingAfterBothRooksMoved() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 
 		position.add( Side.WHITE, "a1", PieceType.ROOK );
 		position.add( Side.WHITE, "e1", PieceType.KING );

--- a/src/test/java/com/leokom/chess/player/legalMover/CenterControlEvaluatorTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/CenterControlEvaluatorTest.java
@@ -18,7 +18,7 @@ public class CenterControlEvaluatorTest {
 
 	@Test
 	public void evaluateMove() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "c3", PieceType.KING );
 
 		//controls d5, d4
@@ -31,7 +31,7 @@ public class CenterControlEvaluatorTest {
 
 	@Test
 	public void givenKnightShouldD5ProveImportance() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "a6", PieceType.KNIGHT );
 
 		Move toAttackD5 = new Move( "a6", "c7" );
@@ -42,7 +42,7 @@ public class CenterControlEvaluatorTest {
 
 	@Test
 	public void blackKingToCenter() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.BLACK, "e7", PieceType.KING );
 
 		//controls d5, e5
@@ -55,7 +55,7 @@ public class CenterControlEvaluatorTest {
 
 	@Test
 	public void kingNearCenterBetterThanToBorder() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.BLACK, "b5", PieceType.KING );
 
 		Move toCenter = new Move( "b5", "c5" );
@@ -66,7 +66,7 @@ public class CenterControlEvaluatorTest {
 
 	@Test
 	public void kingIsCoolAtC3() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.BLACK, "b3", PieceType.KING );
 
 		//attacks d4
@@ -78,7 +78,7 @@ public class CenterControlEvaluatorTest {
 
 	@Test
 	public void f6AlsoGivesControl() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "f7", PieceType.KING );
 
 		//attacks d4
@@ -90,7 +90,7 @@ public class CenterControlEvaluatorTest {
 
 	@Test
 	public void rookTriangulate() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "f7", PieceType.ROOK );
 
 		Move toEFile = new Move( "f7", "e7" );

--- a/src/test/java/com/leokom/chess/player/legalMover/EvaluatorAsserts.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/EvaluatorAsserts.java
@@ -2,6 +2,7 @@ package com.leokom.chess.player.legalMover;
 
 import com.leokom.chess.engine.Move;
 import com.leokom.chess.engine.Position;
+import com.leokom.chess.engine.PositionBuilder;
 
 import static org.junit.Assert.assertTrue;
 
@@ -14,6 +15,10 @@ public class EvaluatorAsserts {
 
 	public EvaluatorAsserts( Evaluator evaluator ) {
 		this.evaluator = evaluator;
+	}
+
+	void assertFirstBetter( PositionBuilder position, Move expectedBetter, Move expectedWorse ) {
+		assertFirstBetter( position.setSideOf( expectedBetter.getFrom() ).build(), expectedBetter, expectedWorse );
 	}
 
 	void assertFirstBetter( Position position, Move expectedBetter, Move expectedWorse ) {

--- a/src/test/java/com/leokom/chess/player/legalMover/LegalPlayerSelfPlayTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/LegalPlayerSelfPlayTest.java
@@ -21,8 +21,8 @@ public class LegalPlayerSelfPlayTest {
 
 	@Test
 	public void twoLegalPlayers() {
-		Player legalPlayerWhite = new LegalPlayer( Side.WHITE );
-		Player legalPlayerBlack = new LegalPlayer( Side.BLACK );
+		Player legalPlayerWhite = new LegalPlayer();
+		Player legalPlayerBlack = new LegalPlayer();
 
 		legalPlayerWhite.setOpponent( legalPlayerBlack );
 		legalPlayerBlack.setOpponent( legalPlayerWhite );
@@ -34,10 +34,10 @@ public class LegalPlayerSelfPlayTest {
 	//but it has.
 	@Test
 	public void twoLegalPlayersNotInjectedPositionStrangeInfluence() {
-		Player legalPlayerWhite = new LegalPlayer( Side.WHITE );
-		Player legalPlayerBlack = new LegalPlayer( Side.BLACK );
+		Player legalPlayerWhite = new LegalPlayer();
+		Player legalPlayerBlack = new LegalPlayer();
 
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "a1", PieceType.KING );
 		position.add( Side.BLACK, "c1", PieceType.KING );
 

--- a/src/test/java/com/leokom/chess/player/legalMover/LegalPlayerTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/LegalPlayerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 public class LegalPlayerTest {
 	@Test
 	public void legalPlayerCreation() {
-		new LegalPlayer( Side.WHITE );
+		new LegalPlayer();
 	}
 
 	@Test
@@ -28,10 +28,10 @@ public class LegalPlayerTest {
 		Player opponent = mock( Player.class );
 
 		//assuming playing as white...
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.WHITE, "a1", PieceType.KING );
 		position.add( Side.BLACK, "c2", PieceType.KING );
 
@@ -55,10 +55,10 @@ public class LegalPlayerTest {
 	public void legalPlayerExecutesSingleAllowedMoveTriangulate() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.WHITE, "h8", PieceType.KING );
 		position.add( Side.BLACK, "g5", PieceType.KING );
 
@@ -75,7 +75,7 @@ public class LegalPlayerTest {
 	public void legalPlayerCanMoveFirstAfterRun() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
 		player.opponentSuggestsMeStartNewGameWhite();
@@ -87,10 +87,10 @@ public class LegalPlayerTest {
 	public void legalPlayerCanMoveFirst() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "h8", PieceType.KING );
 		position.add( Side.BLACK, "g6", PieceType.KING );
 
@@ -105,7 +105,7 @@ public class LegalPlayerTest {
 	public void initialPositionPossibleMovement() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
 		player.opponentSuggestsMeStartNewGameWhite(); //our first move!
@@ -118,7 +118,7 @@ public class LegalPlayerTest {
 	public void secondMoveCanAlsoBeDone() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
 		player.opponentSuggestsMeStartNewGameWhite(); //our first move!
@@ -137,7 +137,7 @@ public class LegalPlayerTest {
 	public void secondMoveTriangulate() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
 		player.opponentSuggestsMeStartNewGameWhite();
@@ -148,7 +148,7 @@ public class LegalPlayerTest {
 	public void noCrashAfterKnightMove() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
 		player.opponentSuggestsMeStartNewGameWhite();
@@ -160,7 +160,7 @@ public class LegalPlayerTest {
 	public void proveNeedToUpdatePositionAfterOurMove() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.WHITE );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
 		final Position position = new Position();
@@ -192,10 +192,10 @@ public class LegalPlayerTest {
 	public void proveNeedToUpdatePositionAfterOurMoveInRecursiveCase() {
 		Player opponent = mock( Player.class );
 
-		final LegalPlayer player = new LegalPlayer( Side.WHITE );
+		final LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
-		final Position position = new Position();
+		final Position position = new Position( Side.WHITE );
 
 		//white King surrounded
 		position.add( Side.WHITE, "h8", PieceType.KING );
@@ -228,10 +228,10 @@ public class LegalPlayerTest {
 	public void blackMoving() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.BLACK );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
-		final Position position = new Position();
+		final Position position = new Position( Side.WHITE );
 
 		position.add( Side.WHITE, "d1", PieceType.KING );
 		position.add( Side.BLACK, "a1", PieceType.KING );
@@ -250,10 +250,10 @@ public class LegalPlayerTest {
 	public void legalPlayerCanStartNewGameInMiddleOfExisting() {
 		Player opponent = mock( Player.class );
 
-		LegalPlayer player = new LegalPlayer( Side.BLACK );
+		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
-		final Position position = new Position();
+		final Position position = new Position( Side.WHITE );
 		//pieces not on initial position to make sure no 'accident'
 		//correct move
 		position.add( Side.WHITE, "d1", PieceType.KING );
@@ -266,7 +266,7 @@ public class LegalPlayerTest {
 		verify( opponent ).opponentMoved( legalPlayerMove.capture() );
 
 		assertTrue( "Legal player must play legally after switch of sides. Actual move: " + legalPlayerMove.getValue(),
-				Position.getInitialPosition().getMoves( Side.WHITE ).stream()
+				Position.getInitialPosition().getMoves().stream()
 				.filter( stringMove ->
 						stringMove.equals( legalPlayerMove.getValue() ) )
 				.findAny().isPresent());

--- a/src/test/java/com/leokom/chess/player/legalMover/LegalPlayerTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/LegalPlayerTest.java
@@ -1,9 +1,6 @@
 package com.leokom.chess.player.legalMover;
 
-import com.leokom.chess.engine.Move;
-import com.leokom.chess.engine.PieceType;
-import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
+import com.leokom.chess.engine.*;
 import com.leokom.chess.player.Player;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -163,7 +160,7 @@ public class LegalPlayerTest {
 		LegalPlayer player = new LegalPlayer();
 		player.setOpponent( opponent );
 
-		final Position position = new Position();
+		Position position = new Position( Side.WHITE );
 
 		//white King surrounded
 		position.add( Side.WHITE, "h8", PieceType.KING );

--- a/src/test/java/com/leokom/chess/player/legalMover/MasterEvaluatorTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/MasterEvaluatorTest.java
@@ -1,9 +1,6 @@
 package com.leokom.chess.player.legalMover;
 
-import com.leokom.chess.engine.Move;
-import com.leokom.chess.engine.PieceType;
-import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
+import com.leokom.chess.engine.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,7 +17,7 @@ public class MasterEvaluatorTest {
 	 */
 	@Test
 	public void beSmartALittle() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "g6", PieceType.QUEEN );
 		position.add( Side.BLACK, "g7", PieceType.PAWN );
 		//protects the pawn

--- a/src/test/java/com/leokom/chess/player/legalMover/MaterialEvaluatorTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/MaterialEvaluatorTest.java
@@ -1,9 +1,6 @@
 package com.leokom.chess.player.legalMover;
 
-import com.leokom.chess.engine.Move;
-import com.leokom.chess.engine.PieceType;
-import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
+import com.leokom.chess.engine.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,7 +18,7 @@ public class MaterialEvaluatorTest {
 
 	@Test
 	public void shouldCaptureBetter(){
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e4", PieceType.PAWN );
 		position.add( Side.BLACK, "d5", PieceType.PAWN );
 
@@ -34,7 +31,7 @@ public class MaterialEvaluatorTest {
 
 	@Test
 	public void unHardCodeD5() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e4", PieceType.QUEEN );
 		position.add( Side.BLACK, "e8", PieceType.PAWN );
 
@@ -47,7 +44,7 @@ public class MaterialEvaluatorTest {
 
 	@Test
 	public void shouldPromotionGiveMaterialBenefit() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e7", PieceType.PAWN );
 		position.add( Side.WHITE, "b2", PieceType.PAWN );
 
@@ -61,7 +58,7 @@ public class MaterialEvaluatorTest {
 
 	@Test
 	public void shouldPromotionToHigherPieceGiveMaterialBenefit() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "e7", PieceType.PAWN );
 
 		Move toBishop = new Move( "e7", "e8B" );

--- a/src/test/java/com/leokom/chess/player/legalMover/MobilityEvaluatorTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/MobilityEvaluatorTest.java
@@ -21,7 +21,7 @@ public class MobilityEvaluatorTest {
 
 	@Test
 	public void shouldQueenControlMore() {
-		Position position = new Position();
+		Position position = new Position( Side.WHITE );
 		position.add( Side.WHITE, "a1", PieceType.QUEEN );
 
 		Move expectedBetter = new Move( "a1", "d4" ); //high mobility
@@ -32,7 +32,7 @@ public class MobilityEvaluatorTest {
 
 	@Test
 	public void shouldKingHaveMoreFreedom() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.BLACK, "f8", PieceType.KING );
 
 		position.add( Side.WHITE, "e8", PieceType.KNIGHT );

--- a/src/test/java/com/leokom/chess/player/legalMover/ProtectionEvaluatorTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/ProtectionEvaluatorTest.java
@@ -1,9 +1,6 @@
 package com.leokom.chess.player.legalMover;
 
-import com.leokom.chess.engine.Move;
-import com.leokom.chess.engine.PieceType;
-import com.leokom.chess.engine.Position;
-import com.leokom.chess.engine.Side;
+import com.leokom.chess.engine.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,7 +16,7 @@ public class ProtectionEvaluatorTest {
 
 	@Test
 	public void leaveAttackedSquare() {
-		Position position = new Position();
+		PositionBuilder position = new PositionBuilder();
 		position.add( Side.WHITE, "h8", PieceType.ROOK );
 		position.add( Side.WHITE, "c2", PieceType.PAWN );
 

--- a/src/test/java/com/leokom/chess/player/legalMover/ProtectionEvaluatorTest.java
+++ b/src/test/java/com/leokom/chess/player/legalMover/ProtectionEvaluatorTest.java
@@ -34,7 +34,7 @@ public class ProtectionEvaluatorTest {
 
 	@Test
 	public void doubleAttackMeansNeedToAct() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		//attacks b3, d3
 		position.add( Side.WHITE, "c1", PieceType.KNIGHT );
 
@@ -51,7 +51,7 @@ public class ProtectionEvaluatorTest {
 
 	@Test
 	public void reactiveProtectingBetterThanNot() {
-		Position position = new Position();
+		Position position = new Position( Side.BLACK );
 		position.add( Side.WHITE, "a1", PieceType.QUEEN );
 
 		position.add( Side.BLACK, "h5", PieceType.KNIGHT );

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -114,14 +114,12 @@ public class WinBoardPlayerIntegrationTest {
 		final Player opponent = mock( Player.class );
 		player.setOpponent( opponent );
 
-		when( communicator.receive() ).thenReturn( "usermove f2f3" );
-		doAnswer( invocation -> { player.opponentMoved( new Move( "e7", "e5" ) ); return null; } )
-			.when( opponent ).opponentMoved( new Move( "f2", "f3" ) );
-		when( communicator.receive() ).thenReturn( "usermove g2g4" );
-		doAnswer( invocation -> { player.opponentMoved( new Move( "d8", "h4" ) ); player.applyShuttingDown(); return null; } )
-				.when( opponent ).opponentMoved( new Move( "g2", "g4" ) );
-
-		player.opponentSuggestsMeStartNewGameWhite();
+		new WinboardTestGameBuilder( player, communicator )
+		.move( new Move( "f2", "f3" ) )
+		.move( new Move( "e7", "e5" ) )
+		.move( new Move( "g2", "g4" ) )
+		.moveLast( new Move( "d8", "h4" ) )
+		.play();
 
 		//TODO: reason should be parametrized
 		verify( communicator, atLeastOnce() ).send( "0-1 {reason}" );

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -133,7 +133,7 @@ public class WinBoardPlayerIntegrationTest {
 				.move( new Move( "g7", "g5" ) )
 				.move( new Move( "b1", "c3" ) )
 				.move( new Move( "f7", "f5" ) )
-				.moveLast( new Move( "d1", "h5" ) )
+				.move( new Move( "d1", "h5" ) )
 				.play();
 
 		verify( communicator ).send( "1-0 {LeokomChess : checkmate}" );
@@ -154,7 +154,7 @@ public class WinBoardPlayerIntegrationTest {
 		.move( new Move( "f2", "f3" ) )
 		.move( new Move( "e7", "e5" ) )
 		.move( new Move( "g2", "g4" ) )
-		.moveLast( new Move( "d8", "h4" ) )
+		.move( new Move( "d8", "h4" ) )
 		.play();
 
 		verify( communicator ).send( "0-1 {LeokomChess : checkmate}" );
@@ -169,10 +169,9 @@ public class WinBoardPlayerIntegrationTest {
 
 		new WinboardTestGameBuilder( player, communicator )
 				.move( new Move( "f2", "f3" ) )
-				.moveLast( new Move( "e7", "e5" ) )
+				.move( new Move( "e7", "e5" ) )
 				.play();
 
-		//TODO: reason should be parametrized
 		verify( communicator, never() ).send( "0-1 {LeokomChess : checkmate}" );
 	}
 

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -84,7 +84,8 @@ public class WinBoardPlayerIntegrationTest {
  	@Test
 	public void promotionCorrectlyTranslatedToCommonStandard() {
 		PositionBuilder position = new PositionBuilder()
-				.addPawn( Side.WHITE, "f7" );
+				.addPawn( Side.WHITE, "f7" )
+				.setSideOf( "f7" );
 
 		player.setPosition( position.build() );
 
@@ -96,7 +97,8 @@ public class WinBoardPlayerIntegrationTest {
 	@Test
 	public void promotionCorrectlyTranslatedFromCommonStandard() {
 		PositionBuilder position = new PositionBuilder()
-				.addPawn( Side.WHITE, "f7" );
+				.addPawn( Side.WHITE, "f7" )
+				.setSideOf( "f7" );
 
 		player.setPosition( position.build() );
 

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -125,6 +125,21 @@ public class WinBoardPlayerIntegrationTest {
 		verify( communicator, atLeastOnce() ).send( "0-1 {reason}" );
 	}
 
+	@Test
+	public void noCheckmateNoFalseInforming() {
+		//implementing fool's mate
+		final Player opponent = mock( Player.class );
+		player.setOpponent( opponent );
+
+		new WinboardTestGameBuilder( player, communicator )
+				.move( new Move( "f2", "f3" ) )
+				.moveLast( new Move( "e7", "e5" ) )
+				.play();
+
+		//TODO: reason should be parametrized
+		verify( communicator, never() ).send( "0-1 {reason}" );
+	}
+
 	private void assertTranslationOfCommandFromPlayerToWinboardClient( Move playerMove, String commandSentToWinboardClient ) {
 
 		//TODO: I don't like this reset, but player sends several commands

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -136,7 +136,7 @@ public class WinBoardPlayerIntegrationTest {
 				.moveLast( new Move( "d1", "h5" ) )
 				.play();
 
-		verify( communicator, atLeastOnce() ).send( "1-0 {LeokomChess reason}" );
+		verify( communicator, atLeastOnce() ).send( "1-0 {LeokomChess : checkmate}" );
 	}
 
 	//Winboard vs Player (White vs Black)
@@ -156,8 +156,7 @@ public class WinBoardPlayerIntegrationTest {
 		.moveLast( new Move( "d8", "h4" ) )
 		.play();
 
-		//TODO: reason should be parametrized
-		verify( communicator, atLeastOnce() ).send( "0-1 {LeokomChess reason}" );
+		verify( communicator, atLeastOnce() ).send( "0-1 {LeokomChess : checkmate}" );
 	}
 
 	@Test
@@ -172,7 +171,7 @@ public class WinBoardPlayerIntegrationTest {
 				.play();
 
 		//TODO: reason should be parametrized
-		verify( communicator, never() ).send( "0-1 {LeokomChess reason}" );
+		verify( communicator, never() ).send( "0-1 {LeokomChess : checkmate}" );
 	}
 
 	private void assertTranslationOfCommandFromPlayerToWinboardClient( Move playerMove, String commandSentToWinboardClient ) {

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -137,6 +137,7 @@ public class WinBoardPlayerIntegrationTest {
 				.play();
 
 		verify( communicator, atLeastOnce() ).send( "1-0 {LeokomChess : checkmate}" );
+		verify( communicator, never() ).send( "0-1 {LeokomChess : checkmate}" );
 	}
 
 	//Winboard vs Player (White vs Black)
@@ -157,6 +158,7 @@ public class WinBoardPlayerIntegrationTest {
 		.play();
 
 		verify( communicator, atLeastOnce() ).send( "0-1 {LeokomChess : checkmate}" );
+		verify( communicator, never() ).send( "1-0 {LeokomChess : checkmate}" );
 	}
 
 	@Test

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -1,6 +1,9 @@
 package com.leokom.chess.player.winboard;
 
 import com.leokom.chess.engine.Move;
+import com.leokom.chess.engine.PieceType;
+import com.leokom.chess.engine.PositionBuilder;
+import com.leokom.chess.engine.Side;
 import com.leokom.chess.player.Player;
 import org.junit.Before;
 import org.junit.Test;
@@ -80,6 +83,10 @@ public class WinBoardPlayerIntegrationTest {
 	//Winboard -> Player
  	@Test
 	public void promotionCorrectlyTranslatedToCommonStandard() {
+		PositionBuilder position = new PositionBuilder()
+				.addPawn( Side.WHITE, "f7" );
+
+		player.setPosition( position.build() );
 
 		assertTranslationOfReceivedCommandToMoveForOpponent(
 				"usermove f7g8q", "f7", "g8Q" );
@@ -88,6 +95,11 @@ public class WinBoardPlayerIntegrationTest {
 	//Player -> Winboard
 	@Test
 	public void promotionCorrectlyTranslatedFromCommonStandard() {
+		PositionBuilder position = new PositionBuilder()
+				.addPawn( Side.WHITE, "f7" );
+
+		player.setPosition( position.build() );
+
 		assertTranslationOfCommandFromPlayerToWinboardClient(
 				new Move( "f7", "f8Q" ), "move f7f8q" );
 	}
@@ -100,6 +112,12 @@ public class WinBoardPlayerIntegrationTest {
 
 	@Test
 	public void castlingCorrectlyTranslatedToWinboardClient() {
+		PositionBuilder position = new PositionBuilder()
+				.add( Side.BLACK, "e8", PieceType.KING )
+				.add( Side.BLACK, "a8", PieceType.ROOK );
+
+		player.setPosition( position.setSideOf( "e8" ).build() );
+
 		assertTranslationOfCommandFromPlayerToWinboardClient(
 				new Move( "e8", "c8" ), "move e8c8" );
 	}

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -5,6 +5,7 @@ import com.leokom.chess.player.Player;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**
@@ -105,6 +106,23 @@ public class WinBoardPlayerIntegrationTest {
 	public void castlingCorrectlyTranslatedToWinboardClient() {
 		assertTranslationOfCommandFromPlayerToWinboardClient(
 				new Move( "e8", "c8" ), "move e8c8" );
+	}
+
+	@Test
+	public void checkmateFromPlayerToWinboard() {
+		//implementing fool's mate
+
+		final WinboardCommunicator communicator = mock( WinboardCommunicator.class );
+		final WinboardCommander commander = new WinboardCommanderImpl( communicator );
+		final WinboardPlayer player = new WinboardPlayer( commander );
+
+		final Player opponent = mock( Player.class );
+		player.setOpponent( opponent );
+
+		fail( "Not implemented yet" );
+		//TODO:
+		//1. f3 e5
+		//2. g4?? Qh4#
 	}
 
 	private void assertTranslationOfCommandFromPlayerToWinboardClient( Move playerMove, String commandSentToWinboardClient ) {

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -2,6 +2,7 @@ package com.leokom.chess.player.winboard;
 
 import com.leokom.chess.engine.Move;
 import com.leokom.chess.player.Player;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -18,23 +19,27 @@ import static org.mockito.Mockito.*;
  * Date-time: 10.11.12 22:03
  */
 public class WinBoardPlayerIntegrationTest {
+
+	private WinboardCommunicator communicator;
+	private WinboardCommander commander;
+	private WinboardPlayer player;
+
+	@Before
+	public void prepare() {
+		communicator = mock( WinboardCommunicator.class );
+		commander = new WinboardCommanderImpl( communicator );
+		player = new WinboardPlayer( commander );
+	}
+
 	@Test
 	public void switchesWinboardToSetUpMode() {
 		//The commander mock is actually EMULATOR OF Winboard behaviour!
-		WinboardCommunicator communicator = mock( WinboardCommunicator.class );
-
-		new WinboardPlayer( new WinboardCommanderImpl( communicator ) );
-
 		verify( communicator ).send( "feature done=0" );
 	}
 
 
 	@Test
 	public void offerDrawListenerCalled() {
-		final WinboardCommunicator communicator = mock( WinboardCommunicator.class );
-
-		final WinboardCommander commander = new WinboardCommanderImpl( communicator );
-		final WinboardPlayer player = new WinboardPlayer( commander );
 		final Player opponent = mock( Player.class );
 		player.setOpponent( opponent );
 
@@ -48,10 +53,6 @@ public class WinBoardPlayerIntegrationTest {
 
 	@Test
 	public void resignListenerCalled() {
-		final WinboardCommunicator communicator = mock( WinboardCommunicator.class );
-
-		final WinboardCommander commander = new WinboardCommanderImpl( communicator );
-		final WinboardPlayer player = new WinboardPlayer( commander );
 		final Player opponent = mock( Player.class );
 		player.setOpponent( opponent );
 
@@ -68,10 +69,6 @@ public class WinBoardPlayerIntegrationTest {
 
 	@Test
 	public void userMoveNoException() {
-		final WinboardCommunicator communicator = mock( WinboardCommunicator.class );
-
-		final WinboardCommander commander = new WinboardCommanderImpl( communicator );
-		final WinboardPlayer player = new WinboardPlayer( commander );
 		player.setOpponent( mock( Player.class ) );
 
 		//low-level
@@ -108,27 +105,21 @@ public class WinBoardPlayerIntegrationTest {
 				new Move( "e8", "c8" ), "move e8c8" );
 	}
 
+	//Winboard vs Player (White vs Black)
+	//1. f3 e5
+	//2. g4?? Qh4#
+	//need to inform UI that it lost (and Player won!)
 	@Test
 	public void checkmateFromPlayerToWinboard() {
 		//implementing fool's mate
-
-		final WinboardCommunicator communicator = mock( WinboardCommunicator.class );
-		final WinboardCommander commander = new WinboardCommanderImpl( communicator );
-		final WinboardPlayer player = new WinboardPlayer( commander );
 
 		final Player opponent = mock( Player.class );
 		player.setOpponent( opponent );
 
 		fail( "Not implemented yet" );
-		//TODO:
-		//1. f3 e5
-		//2. g4?? Qh4#
 	}
 
 	private void assertTranslationOfCommandFromPlayerToWinboardClient( Move playerMove, String commandSentToWinboardClient ) {
-		final WinboardCommunicator communicator = mock( WinboardCommunicator.class );
-		final WinboardCommander commander = new WinboardCommanderImpl( communicator );
-		final WinboardPlayer player = new WinboardPlayer( commander );
 
 		//TODO: I don't like this reset, but player sends several commands
 		//like set features etc, how to do better?
@@ -141,9 +132,6 @@ public class WinBoardPlayerIntegrationTest {
 	}
 
 	private void assertTranslationOfReceivedCommandToMoveForOpponent( String winboardReceivedMessage, String squareFrom, String destination ) {
-		final WinboardCommunicator communicator = mock( WinboardCommunicator.class );
-		final WinboardCommander commander = new WinboardCommanderImpl( communicator );
-		final WinboardPlayer player = new WinboardPlayer( commander );
 		Player opponent = mock( Player.class );
 
 		player.setOpponent( opponent );

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -112,9 +112,12 @@ public class WinBoardPlayerIntegrationTest {
 	@Test
 	public void checkmateFromPlayerToWinboard() {
 		//implementing fool's mate
-
 		final Player opponent = mock( Player.class );
 		player.setOpponent( opponent );
+
+		player.opponentSuggestsMeStartNewGameWhite();
+
+
 
 		fail( "Not implemented yet" );
 	}

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -136,7 +136,7 @@ public class WinBoardPlayerIntegrationTest {
 				.moveLast( new Move( "d1", "h5" ) )
 				.play();
 
-		verify( communicator, atLeastOnce() ).send( "1-0 {LeokomChess : checkmate}" );
+		verify( communicator ).send( "1-0 {LeokomChess : checkmate}" );
 		verify( communicator, never() ).send( "0-1 {LeokomChess : checkmate}" );
 	}
 
@@ -157,7 +157,7 @@ public class WinBoardPlayerIntegrationTest {
 		.moveLast( new Move( "d8", "h4" ) )
 		.play();
 
-		verify( communicator, atLeastOnce() ).send( "0-1 {LeokomChess : checkmate}" );
+		verify( communicator ).send( "0-1 {LeokomChess : checkmate}" );
 		verify( communicator, never() ).send( "1-0 {LeokomChess : checkmate}" );
 	}
 

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -122,7 +122,7 @@ public class WinBoardPlayerIntegrationTest {
 		.play();
 
 		//TODO: reason should be parametrized
-		verify( communicator, atLeastOnce() ).send( "0-1 {reason}" );
+		verify( communicator, atLeastOnce() ).send( "0-1 {LeokomChess reason}" );
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class WinBoardPlayerIntegrationTest {
 				.play();
 
 		//TODO: reason should be parametrized
-		verify( communicator, never() ).send( "0-1 {reason}" );
+		verify( communicator, never() ).send( "0-1 {LeokomChess reason}" );
 	}
 
 	private void assertTranslationOfCommandFromPlayerToWinboardClient( Move playerMove, String commandSentToWinboardClient ) {

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -122,6 +122,9 @@ public class WinBoardPlayerIntegrationTest {
 				.when( opponent ).opponentMoved( new Move( "g2", "g4" ) );
 
 		player.opponentSuggestsMeStartNewGameWhite();
+
+		//TODO: reason should be parametrized
+		verify( communicator, atLeastOnce() ).send( "0-1 {reason}" );
 	}
 
 	private void assertTranslationOfCommandFromPlayerToWinboardClient( Move playerMove, String commandSentToWinboardClient ) {

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -6,7 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**
@@ -115,11 +114,14 @@ public class WinBoardPlayerIntegrationTest {
 		final Player opponent = mock( Player.class );
 		player.setOpponent( opponent );
 
+		when( communicator.receive() ).thenReturn( "usermove f2f3" );
+		doAnswer( invocation -> { player.opponentMoved( new Move( "e7", "e5" ) ); return null; } )
+			.when( opponent ).opponentMoved( new Move( "f2", "f3" ) );
+		when( communicator.receive() ).thenReturn( "usermove g2g4" );
+		doAnswer( invocation -> { player.opponentMoved( new Move( "d8", "h4" ) ); player.applyShuttingDown(); return null; } )
+				.when( opponent ).opponentMoved( new Move( "g2", "g4" ) );
+
 		player.opponentSuggestsMeStartNewGameWhite();
-
-
-
-		fail( "Not implemented yet" );
 	}
 
 	private void assertTranslationOfCommandFromPlayerToWinboardClient( Move playerMove, String commandSentToWinboardClient ) {

--- a/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinBoardPlayerIntegrationTest.java
@@ -122,6 +122,23 @@ public class WinBoardPlayerIntegrationTest {
 				new Move( "e8", "c8" ), "move e8c8" );
 	}
 
+	@Test
+	public void checkmateWhenWinboardWins() {
+		//implementing fool's mate
+		final Player opponent = mock( Player.class );
+		player.setOpponent( opponent );
+
+		new WinboardTestGameBuilder( player, communicator )
+				.move( new Move( "e2", "e4" ) )
+				.move( new Move( "g7", "g5" ) )
+				.move( new Move( "b1", "c3" ) )
+				.move( new Move( "f7", "f5" ) )
+				.moveLast( new Move( "d1", "h5" ) )
+				.play();
+
+		verify( communicator, atLeastOnce() ).send( "1-0 {LeokomChess reason}" );
+	}
+
 	//Winboard vs Player (White vs Black)
 	//1. f3 e5
 	//2. g4?? Qh4#

--- a/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
@@ -50,14 +50,28 @@ public class WinboardTestGameBuilder {
 		return this;
 	}
 
-	//TODO: highly depends on knowledge of 'Black' moving last
 	//not very 'nice' to force caller use this method
 	//but for now it's simpler than keeping more state in the builder
 	public WinboardTestGameBuilder moveLast( Move move ) {
-		//ensure no infinite loop is continued after the last move
+		switch ( sideToMove ) {
+			case WHITE:
+				communicatorReceive = communicatorReceive.
+						thenAnswer( invocation -> {
+							player.applyShuttingDown();
+							return "usermove " + move.getFrom() + move.getTo();
+						} );
+						//thenReturn( "usermove " + move.getFrom() + move.getTo() );
 
-		doAnswer( invocation -> { player.opponentMoved( move ); player.applyShuttingDown(); return null; } )
-				.when( opponent ).opponentMoved( lastMove );
+				break;
+			case BLACK:
+				//ensure no infinite loop is continued after the last move
+				doAnswer( invocation -> { player.opponentMoved( move ); player.applyShuttingDown(); return null; } )
+						.when( opponent ).opponentMoved( lastMove );
+				break;
+
+		}
+
+
 
 		return this;
 	}

--- a/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
@@ -50,32 +50,9 @@ public class WinboardTestGameBuilder {
 		return this;
 	}
 
-	//not very 'nice' to force caller use this method
-	//but for now it's simpler than keeping more state in the builder
-	public WinboardTestGameBuilder moveLast( Move move ) {
-		switch ( sideToMove ) {
-			case WHITE:
-				communicatorReceive = communicatorReceive.
-						thenAnswer( invocation -> {
-							player.applyShuttingDown();
-							return "usermove " + move.getFrom() + move.getTo();
-						} )
-						.thenReturn( "" );
-
-				break;
-			case BLACK:
-				//ensure no infinite loop is continued after the last move
-				doAnswer( invocation -> { player.opponentMoved( move ); player.applyShuttingDown(); return null; } )
-						.when( opponent ).opponentMoved( lastMove );
-
-				communicatorReceive = communicatorReceive.thenReturn( "" );
-				break;
-		}
-
-		return this;
-	}
-
 	public void play() {
+		//ensure no infinite loop is continued after the last move
+		communicatorReceive = communicatorReceive.thenReturn( "quit" );
 		player.opponentSuggestsMeStartNewGameWhite();
 	}
 }

--- a/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
@@ -1,0 +1,68 @@
+package com.leokom.chess.player.winboard;
+
+import com.leokom.chess.engine.Move;
+import com.leokom.chess.engine.Side;
+import com.leokom.chess.player.Player;
+import org.mockito.stubbing.OngoingStubbing;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Author: Leonid
+ * Date-time: 22.02.15 21:27
+ */
+public class WinboardTestGameBuilder {
+	private final Player opponent;
+	private final WinboardPlayer player;
+	public WinboardTestGameBuilder(
+		WinboardPlayer player,
+		WinboardCommunicator communicator ) {
+		this.player = player;
+		this.opponent =	mock( Player.class );
+
+		programCommunicator = when( communicator.receive() );
+
+		player.setOpponent( opponent );
+	}
+
+	private Move lastMove;
+	private Side sideToMove = Side.WHITE;
+
+	//Mockito feature to program consecutive calls
+	final OngoingStubbing<String> programCommunicator;
+
+	//highly depends on knowledge that Winboard: White, opponent Black
+	public WinboardTestGameBuilder move( Move move ) {
+		switch ( sideToMove ) {
+		case WHITE:
+			programCommunicator.thenReturn( "usermove " + move.getFrom() + move.getTo() );
+			break;
+		case BLACK:
+			doAnswer( invocation -> { player.opponentMoved( move ); return null; } )
+					.when( opponent ).opponentMoved( lastMove );
+		}
+
+		lastMove = move;
+
+		sideToMove = sideToMove.opposite();
+		return this;
+	}
+
+	//TODO: highly depends on knowledge of 'Black' moving last
+	//not very 'nice' to force caller use this method
+	//but for now it's simpler than keeping more state in the builder
+	public WinboardTestGameBuilder moveLast( Move move ) {
+		//ensure no infinite loop is continued after the last move
+
+		doAnswer( invocation -> { player.opponentMoved( move ); player.applyShuttingDown(); return null; } )
+				.when( opponent ).opponentMoved( lastMove );
+
+		return this;
+	}
+
+	public void play() {
+		player.opponentSuggestsMeStartNewGameWhite();
+	}
+}

--- a/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
@@ -59,19 +59,18 @@ public class WinboardTestGameBuilder {
 						thenAnswer( invocation -> {
 							player.applyShuttingDown();
 							return "usermove " + move.getFrom() + move.getTo();
-						} );
-						//thenReturn( "usermove " + move.getFrom() + move.getTo() );
+						} )
+						.thenReturn( "" );
 
 				break;
 			case BLACK:
 				//ensure no infinite loop is continued after the last move
 				doAnswer( invocation -> { player.opponentMoved( move ); player.applyShuttingDown(); return null; } )
 						.when( opponent ).opponentMoved( lastMove );
+
+				communicatorReceive = communicatorReceive.thenReturn( "" );
 				break;
-
 		}
-
-
 
 		return this;
 	}

--- a/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
+++ b/src/test/java/com/leokom/chess/player/winboard/WinboardTestGameBuilder.java
@@ -22,7 +22,7 @@ public class WinboardTestGameBuilder {
 		this.player = player;
 		this.opponent =	mock( Player.class );
 
-		programCommunicator = when( communicator.receive() );
+		communicatorReceive = when( communicator.receive() );
 
 		player.setOpponent( opponent );
 	}
@@ -31,13 +31,13 @@ public class WinboardTestGameBuilder {
 	private Side sideToMove = Side.WHITE;
 
 	//Mockito feature to program consecutive calls
-	final OngoingStubbing<String> programCommunicator;
+	private OngoingStubbing<String> communicatorReceive;
 
 	//highly depends on knowledge that Winboard: White, opponent Black
 	public WinboardTestGameBuilder move( Move move ) {
 		switch ( sideToMove ) {
 		case WHITE:
-			programCommunicator.thenReturn( "usermove " + move.getFrom() + move.getTo() );
+			communicatorReceive = communicatorReceive.thenReturn( "usermove " + move.getFrom() + move.getTo() );
 			break;
 		case BLACK:
 			doAnswer( invocation -> { player.opponentMoved( move ); return null; } )


### PR DESCRIPTION
Implements #145.

Detection of checkmate is so far very simple. It's not distinguishable from other terminal states yet.

Need of informing Winboard about checkmate resulted in big architecture difference:
Symmetrically to LegalPlayer, WinboardPlayer:
* now contains Position 
* can inject a Position from tests
* updates Position state about OUR move before informing the opponent
* updates Position state by the opponent's move

Maybe this symmetry will further lead to a central place in system where 'current' position will be accessible.

Position class's goal clarified:
it's a univesal game state, including everything needed to decide which moves are legal now.
Thus: Position class extended:
it encapsulates now the information about Side which has right to move.

Thus 2 positions with same pieces but different sides to move are considered to be different.
For one of evaluators a 'mirror' method has been developed to overcome this.

Players don't need now holding 'Side to move' since it's part of Position.
Evaluators have been simplifying due to the same reason - they don't need Side storage.

Introduced new important PositionBuilder
that should in future enapsulate Position creation and making Position class truly immutable.

Introduced (for tests): WinboardTestBuilder
it's a smart robot that allows programming game state till some point at which we want to develop some new feature (really cool it is!)

Enabling Infinitest by default: #99 
It's stable now and is really HELPFUL in development.


